### PR TITLE
Add run command for Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ The `flutter build apk`, `flutter build ios` (or _macos_) or `flutter build web`
 
 ## Run
 
+### Dart
 ```bash
 dart run sentry_dart_plugin
+```
+
+### Flutter
+```bash
+flutter packages pub run sentry_dart_plugin
 ```
 
 ## Configuration (Optional)


### PR DESCRIPTION
## :scroll: Description
Add the command for Flutter apps to the readme


## :bulb: Motivation and Context
The `dart` command does not work for Flutter apps


## :green_heart: How did you test it?
Locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
None
