### PR TITLE
Fix: Changelog uses 2 sharps due to Craft requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,23 @@
-# Unreleased
+# Changelog
 
-# 1.0.0-beta.1
+## Unreleased
+
+## 1.0.0-beta.1
 
 * Feat: Ability to configure url for on-premise server (#17)
 
-# 1.0.0-alpha.4
+## 1.0.0-alpha.4
 
 * Fix: Log real exitCode, stdout and stdout if available (#13)
 
-# 1.0.0-alpha.3
+## 1.0.0-alpha.3
 
 * Bump sentry-cli 1.69.1 which includes a fix for Dart debug symbols (#8)
 
-# 1.0.0-alpha.2
+## 1.0.0-alpha.2
 
 * Fix: Add org and project when creating releases (#2)
 
-# 1.0.0-alpha.1
+## 1.0.0-alpha.1
 
 * Feat: Sentry Dart Plugin


### PR DESCRIPTION
_#skip-changelog_