### PR TITLE
deps: Update deprecated system_info to system_info_2

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:package_config/package_config.dart';
-import 'package:system_info/system_info.dart';
+import 'package:system_info2/system_info2.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils/extensions.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   yaml: ^3.1.0
   injector: ^2.0.0
   ansicolor: ^2.0.1
-  package_config: ^2.0.0
-  system_info: ^1.0.1
+  package_config: ^2.0.2
+  system_info2: ^2.0.3
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
https://pub.dev/packages/system_info is discontinued.
Use https://pub.dev/packages/system_info2 instead.

#skip-changelog