### PR TITLE
chore: update pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,2 +1,3 @@
+.craft.yml
+integration-test
 scripts
-dangerfile.js


### PR DESCRIPTION
#skip-changelog

Also, is there anything else that needs to be done for [Publish via craft in #43](https://github.com/getsentry/sentry-dart-plugin/issues/43)? The current [craft.yml](https://github.com/getsentry/sentry-dart-plugin/blob/ef0f055fbfa96fbb6505f121cf530fa73f45a8ef/.craft.yml#L6) looks good to me already.