### PR TITLE
chore: rename some configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Rename configuration `include_native_sources` to `upload_sources` ([#78](https://github.com/getsentry/sentry-dart-plugin/pull/78))
+
 ## 1.0.0-beta.5
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Rename configuration `include_native_sources` to `upload_sources` ([#78](https://github.com/getsentry/sentry-dart-plugin/pull/78))
+* Rename configuration `upload_native_symbols` to `upload_debug_symbols` ([#78](https://github.com/getsentry/sentry-dart-plugin/pull/78))
 
 ## 1.0.0-beta.5
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add `sentry:` configuration at the end of your `pubspec.yaml` file:
 
 ```yaml
 sentry:
-  upload_native_symbols: true
+  upload_debug_symbols: true
   upload_source_maps: false
   upload_sources: false
   project: ...
@@ -61,7 +61,7 @@ sentry:
 
 | Configuration Name | Description | Default Value And Type | Required | Alternative Environment variable |
 | - | - | - | - | - |
-| upload_native_symbols | Enables or disables the automatic upload of debug symbols | true (boolean) | no | - |
+| upload_debug_symbols | Enables or disables the automatic upload of debug symbols | true (boolean) | no | - |
 | upload_source_maps | Enables or disables the automatic upload of source maps | false (boolean) | no | - |
 | upload_sources | Does or doesn't include the source code of native code | false (boolean) | no | - |
 | project | Project's name | e.g. sentry-flutter (string) | yes | SENTRY_PROJECT |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add `sentry:` configuration at the end of your `pubspec.yaml` file:
 sentry:
   upload_native_symbols: true
   upload_source_maps: false
-  include_native_sources: false
+  upload_sources: false
   project: ...
   org: ...
   auth_token: ...
@@ -63,7 +63,7 @@ sentry:
 | - | - | - | - | - |
 | upload_native_symbols | Enables or disables the automatic upload of debug symbols | true (boolean) | no | - |
 | upload_source_maps | Enables or disables the automatic upload of source maps | false (boolean) | no | - |
-| include_native_sources | Does or doesn't include the source code of native code | false (boolean) | no | - |
+| upload_sources | Does or doesn't include the source code of native code | false (boolean) | no | - |
 | project | Project's name | e.g. sentry-flutter (string) | yes | SENTRY_PROJECT |
 | org | Organization's slug | e.g. sentry-sdks (string) | yes | SENTRY_ORG |
 | auth_token | Auth Token | e.g. 64 random characteres (string)  | yes | SENTRY_AUTH_TOKEN |

--- a/example/readme.md
+++ b/example/readme.md
@@ -22,7 +22,7 @@ sentry:
   # enabled by default
   #upload_native_symbols: true
   # disabled by default
-  include_native_sources: true
+  upload_sources: true
   # disabled by default
   upload_source_maps: true
   project: sentry-flutter
@@ -43,4 +43,4 @@ sentry:
   # default to name@version from pubspec
   #release: ...
   ```
-  
+

--- a/example/readme.md
+++ b/example/readme.md
@@ -20,7 +20,7 @@ dev_dependencies:
 
 sentry:
   # enabled by default
-  #upload_native_symbols: true
+  #upload_debug_symbols: true
   # disabled by default
   upload_sources: true
   # disabled by default
@@ -43,4 +43,3 @@ sentry:
   # default to name@version from pubspec
   #release: ...
   ```
-

--- a/integration-test/pubspec.yaml
+++ b/integration-test/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
   uses-material-design: true
 
 sentry:
-  upload_native_symbols: true
+  upload_debug_symbols: true
   upload_sources: true
   upload_source_maps: true
   auth_token: sentry-dart-plugin-auth-token

--- a/integration-test/pubspec.yaml
+++ b/integration-test/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 
 sentry:
   upload_native_symbols: true
-  include_native_sources: true
+  upload_sources: true
   upload_source_maps: true
   auth_token: sentry-dart-plugin-auth-token
   project: sentry-dart-plugin

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -27,7 +27,7 @@ class SentryDartPlugin {
         return 1;
       }
 
-      if (_configuration.uploadNativeSymbols) {
+      if (_configuration.uploadDebugSymbols) {
         _executeCliForDebugSymbols();
       } else {
         Log.info('uploadNativeSymbols is disabled.');
@@ -66,7 +66,7 @@ class SentryDartPlugin {
 
     _addOrgAndProject(params);
 
-    if (_configuration.includeSources) {
+    if (_configuration.uploadSources) {
       params.add('--include-sources');
     } else {
       Log.info('includeSources is disabled, not uploading sources.');

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -66,10 +66,10 @@ class SentryDartPlugin {
 
     _addOrgAndProject(params);
 
-    if (_configuration.includeNativeSources) {
+    if (_configuration.includeSources) {
       params.add('--include-sources');
     } else {
-      Log.info('includeNativeSources is disabled, not uploading sources.');
+      Log.info('includeSources is disabled, not uploading sources.');
     }
 
     params.add(_configuration.buildFilesFolder);

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -18,14 +18,14 @@ class Configuration {
   /// The Build folder, defaults to the current directory.
   late final String buildFilesFolder = _fs.currentDirectory.path;
 
-  /// Rather upload native debug symbols, defaults to true
+  /// Whether to upload native debug symbols, defaults to true
   late bool uploadNativeSymbols;
 
-  /// Rather upload source maps, defaults to false
+  /// Whether to upload source maps, defaults to false
   late bool uploadSourceMaps;
 
-  /// Rather upload native source code, defaults to false
-  late bool includeNativeSources;
+  /// Whether to upload source code, defaults to false
+  late bool includeSources;
 
   /// Wait for processing or not, defaults to false
   late bool waitForProcessing;
@@ -92,7 +92,15 @@ class Configuration {
 
     uploadNativeSymbols = config?['upload_native_symbols'] ?? true;
     uploadSourceMaps = config?['upload_source_maps'] ?? false;
-    includeNativeSources = config?['include_native_sources'] ?? false;
+    if (config?['upload_sources'] != null) {
+      includeSources = config?['upload_sources'];
+    } else {
+      includeSources = config?['include_native_sources'] ?? false;
+    }
+    if (config?['include_native_sources'] != null) {
+      Log.warn(
+          'Your pubspec.yaml contains `include_native_sources` which is deprecated. Consider switching to `upload_sources`.');
+    }
     commits = (config?['commits'] ?? 'auto').toString();
 
     // uploading JS and Map files need to have the correct folder structure

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -75,7 +75,7 @@ $configIndented
 
       test('works with pubspec', () async {
         final commandLog = await runWith('''
-      upload_native_symbols: true
+      upload_debug_symbols: true
       upload_sources: true
       upload_source_maps: true
       log_level: debug

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -76,7 +76,7 @@ $configIndented
       test('works with pubspec', () async {
         final commandLog = await runWith('''
       upload_native_symbols: true
-      include_native_sources: true
+      upload_sources: true
       upload_source_maps: true
       log_level: debug
     ''');


### PR DESCRIPTION
* rename `include_native_sources` to still make sense after https://github.com/getsentry/sentry-dart/issues/132 is implemented
* also rename `upload_native_symbols` because it uploads not only native symbols