### PR TITLE
Add ignore_missing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Changes
+### Features
 
 * Add configuration `ignore_missing` ([#85](https://github.com/getsentry/sentry-dart-plugin/pull/85))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Add configuration `ignore_missing` ([#85](https://github.com/getsentry/sentry-dart-plugin/pull/85))
+
 ## 1.0.0
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ sentry:
   release: ...
   web_build_path: ...
   commits: auto
+  ignore_missing: true
 ```
 
 ### Available Configuration Fields
@@ -73,6 +74,7 @@ sentry:
 | release | The release version for source maps, it should match the release set by the SDK | default: name@version from pubspec (string)  | no | SENTRY_RELEASE |
 | web_build_path | The web build folder | default: build/web (string)  | no | - |
 | commits | Release commits integration | default: auto | no | - |
+| ignore_missing | Ignore missing commits previously used in the release | default: false | no | - |
 
 ## Troubleshooting
 

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -113,6 +113,10 @@ class SentryDartPlugin {
       params.add(_configuration.commits);
     }
 
+    if (_configuration.ignoreMissing) {
+      params.add('--ignore-missing');
+    }
+
     _executeAndLog('Failed to set commits', params);
   }
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -64,6 +64,11 @@ class Configuration {
   /// Set to `false` to disable this feature completely.
   late String commits;
 
+  /// Dealing With Missing Commits
+  /// There are scenarios in which your repositories may be missing commits previously used in the release.
+  /// https://docs.sentry.io/product/cli/releases/#dealing-with-missing-commits
+  late bool ignoreMissing;
+
   dynamic _getPubspec() {
     final file = injector.get<FileSystem>().file("pubspec.yaml");
     if (!file.existsSync()) {
@@ -96,6 +101,7 @@ class Configuration {
     uploadSources =
         config?.get('upload_sources', 'include_native_sources') ?? false;
     commits = (config?['commits'] ?? 'auto').toString();
+    ignoreMissing = config?['ignore_missing'] ?? false;
 
     // uploading JS and Map files need to have the correct folder structure
     // otherwise symbolication fails, the default path for the web build folder is build/web

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -79,6 +79,7 @@ $configIndented
       upload_sources: true
       upload_source_maps: true
       log_level: debug
+      ignore_missing: true
     ''');
         final args = '$commonArgs --log-level debug';
         expect(commandLog, [
@@ -86,7 +87,7 @@ $configIndented
           '$cli $args releases $orgAndProject new $release',
           '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js',
           '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart',
-          '$cli $args releases $orgAndProject set-commits $release --auto',
+          '$cli $args releases $orgAndProject set-commits $release --auto --ignore-missing',
           '$cli $args releases $orgAndProject finalize $release'
         ]);
       });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
config to ignore missing commits previously used in the release


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
add option `--ignore-missing` to `sentry-cli releases set-commits` to solve following issue.
```
There are scenarios in which your repositories may be missing commits previously used in the release. This can happen whenever you modify the commit in question by, for example, amending it, rebasing, or squashing multiple commits together. In this case, Sentry CLI will be unable to find it, and will throw an error that the commit cannot be found.
```
https://docs.sentry.io/product/cli/releases/#dealing-with-missing-commits



## :green_heart: How did you test it?
Before fix, I have this error when deploy
```
stderr: error: Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it. Otherwise, it means that the commit we are looking for was amended or squashed and cannot be retrieved. Use --ignore-missing flag to skip it and create a new release with the default commits count.
```
after adding dependency to current pull request branch, the error disappeared
```yml
dev_dependencies:
  sentry_dart_plugin:
    git:
      url: https://github.com/qiuyin/sentry-dart-plugin.git
      ref: add-ignore-missing-option
```


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

Test passed
<img width="1145" alt="スクリーンショット 2023-03-01 23 17 45" src="https://user-images.githubusercontent.com/2759138/222166425-ebfa2301-ac8f-4012-b3cd-430eae9c2284.png">

## :crystal_ball: Next steps
