### PR TITLE
Added the ability to set custom package name in sentry dart plugin

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -93,7 +93,7 @@ class Configuration {
     version = config?['release']?.toString() ??
         environments['SENTRY_RELEASE'] ??
         pubspec['version'].toString(); // or env. var. SENTRY_RELEASE
-    name = pubspec['name'].toString();
+    name = config?['name']?.toString() ?? pubspec['name'].toString();
 
     uploadDebugSymbols =
         config?.get('upload_debug_symbols', 'upload_native_symbols') ?? true;


### PR DESCRIPTION
## :scroll: Description
Different namings between android package name or ios bundle id and pubspec's name.

When a developer uploads source mappings to the sentry dashboard by the current lib, there appears a new release with a package name, which is different from the android package name or ios' bundle id. But when a crash of the app happens, the sentry io of the native side sends a native package names or bundle id which is not the same as the pubspec's package (name@version).
So, the releases of uploading via plugin and crashed ones are different

The decision, add a name parameter of sentry config (configuration.dart -> 96 row)
name = config?['name']?.toString() ?? pubspec['name'].toString();
