### PR TITLE
Support custom dist and release has precedence over the pubspec name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Support custom `dist` and `release` has precedence over the pubspec's `name` ([#127](https://github.com/getsentry/sentry-dart-plugin/pull/127))
+- Support custom `dist` and `release` has precedence over the pubspec's `name` ([#139](https://github.com/getsentry/sentry-dart-plugin/pull/139))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Support custom `dist` and `release` has precedence over the pubspec's `name` ([#127](https://github.com/getsentry/sentry-dart-plugin/pull/127))
+
 ### Dependencies
 
 - Bump CLI from v2.19.1 to v2.19.4 ([#133](https://github.com/getsentry/sentry-dart-plugin/pull/133))

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ sentry:
   wait_for_processing: false
   log_level: error # possible values: trace, debug, info, warn, error
   release: ...
+  dist: ...
   web_build_path: ...
   commits: auto
   ignore_missing: true
@@ -72,6 +73,7 @@ sentry:
 | wait_for_processing | Wait for server-side processing of uploaded files | false (boolean)  | no | - |
 | log_level | Configures the log level for sentry-cli | warn (string)  | no | SENTRY_LOG_LEVEL |
 | release | The release version for source maps, it should match the release set by the SDK | default: name@version from pubspec (string)  | no | SENTRY_RELEASE |
+| dist | The dist/build number for source maps, it should match the dist set by the SDK | default: the number after the '+' char from 'version' pubspec (string)  | no | SENTRY_DIST |
 | web_build_path | The web build folder | default: build/web (string)  | no | - |
 | commits | Release commits integration | default: auto | no | - |
 | ignore_missing | Ignore missing commits previously used in the release | default: false | no | - |

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -48,10 +48,21 @@ class Configuration {
   // the Sentry CLI path, defaults to the assets folder
   late String? cliPath;
 
-  /// The Apps version, defaults to version from pubspec
+  /// The Apps release name, defaults to 'name@version+buildNumber' from pubspec or set via env. var. SENTRY_RELEASE
+  /// Example, name: 'my_app', version: 2.0.0+1, in this case the release is my_app@2.0.0+1
+  /// This field has precedence over the [name] from pubspec
+  /// If this field has a build number, it has precedence over the [version]'s buid number from pubspec
+  late String? release;
+
+  /// The Apps dist/build number, defaults to the build number after the '+' char from [version]'s pubspec or ser via env. var. SENTRY_DIST
+  /// Example, version: 2.0.0+1, in this case the build number is 1
+  late String? dist;
+
+  /// The Apps version, defaults to [version] from pubspec
+  /// Example, version: 2.0.0+1, in this case the version is 2.0.0+1
   late String version;
 
-  /// The Apps name, defaults to name from pubspec
+  /// The Apps name, defaults to [name] from pubspec
   late String name;
 
   /// the Web Build folder, defaults to build/web
@@ -90,9 +101,9 @@ class Configuration {
     final pubspec = _getPubspec();
     final config = pubspec['sentry'] as YamlMap?;
 
-    version = config?['release']?.toString() ??
-        environments['SENTRY_RELEASE'] ??
-        pubspec['version'].toString(); // or env. var. SENTRY_RELEASE
+    release = config?['release']?.toString() ?? environments['SENTRY_RELEASE'];
+    dist = config?['dist']?.toString() ?? environments['SENTRY_DIST'];
+    version = pubspec['version'].toString();
     name = pubspec['name'].toString();
 
     uploadDebugSymbols =

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -137,6 +137,68 @@ $configIndented
           ]);
         });
       });
+
+      group('custom releases and dists', () {
+        test('custom release with a dist in it', () async {
+          final dist = 'myDist';
+          final customRelease = 'myRelease@myVersion+$dist';
+
+          final commandLog = await runWith('''
+      upload_debug_symbols: false
+      upload_source_maps: true
+      release: $customRelease
+      dist: anotherDist
+    ''');
+          final args = commonArgs;
+          expect(commandLog, [
+            '$cli $args releases $orgAndProject new $customRelease',
+            '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
+            '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
+            '$cli $args releases $orgAndProject set-commits $customRelease --auto',
+            '$cli $args releases $orgAndProject finalize $customRelease'
+          ]);
+        });
+
+        test('custom release with a custom dist', () async {
+          final dist = 'myDist';
+          final customRelease = 'myRelease@myVersion';
+          final fullRelease = '$customRelease+$dist';
+
+          final commandLog = await runWith('''
+      upload_debug_symbols: false
+      upload_source_maps: true
+      release: $customRelease
+      dist: $dist
+    ''');
+          final args = commonArgs;
+          expect(commandLog, [
+            '$cli $args releases $orgAndProject new $fullRelease',
+            '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
+            '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
+            '$cli $args releases $orgAndProject set-commits $fullRelease --auto',
+            '$cli $args releases $orgAndProject finalize $fullRelease'
+          ]);
+        });
+
+        test('custom dist', () async {
+          final dist = 'myDist';
+          final fullRelease = '$release+$dist';
+
+          final commandLog = await runWith('''
+      upload_debug_symbols: false
+      upload_source_maps: true
+      dist: $dist
+    ''');
+          final args = commonArgs;
+          expect(commandLog, [
+            '$cli $args releases $orgAndProject new $fullRelease',
+            '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
+            '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
+            '$cli $args releases $orgAndProject set-commits $fullRelease --auto',
+            '$cli $args releases $orgAndProject finalize $fullRelease'
+          ]);
+        });
+      });
     });
   }
 }


### PR DESCRIPTION
## :scroll: Description
Support custom `dist` and `release` has precedence over the pubspec's `name`


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-dart-plugin/issues/137
Closes https://github.com/getsentry/sentry-dart-plugin/issues/132


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated the docs if needed
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
Update the docs