### PR TITLE
Pin flutter version to 3.13.3 in integration test

### DIFF
--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [macos, ubuntu, windows]
     steps:
       - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa #2.10.0
         with:
-          flutter-version: '3.13.2'
+          flutter-version: '3.13.3'
           channel: 'stable'
       - uses: actions/setup-java@v3
         with:
@@ -37,15 +37,7 @@ jobs:
       - run: flutter build ipa --no-codesign
         if: matrix.os == 'macos'
 
-      - name: ls -LR 
-        working-directory: integration-test/build
-        run: ls -LR
-
       - run: flutter build web --source-maps
-
-      - name: ls -LR 
-        working-directory: integration-test/build
-        run: ls -LR
 
       - run: scripts/test.ps1
         shell: pwsh

--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, ubuntu, windows]
+        os: [ubuntu]
     steps:
       - uses: actions/checkout@v3
 
@@ -37,7 +37,15 @@ jobs:
       - run: flutter build ipa --no-codesign
         if: matrix.os == 'macos'
 
+      - name: ls -LR 
+        working-directory: integration-test/build
+        run: ls -LR
+
       - run: flutter build web --source-maps
+
+      - name: ls -LR 
+        working-directory: integration-test/build
+        run: ls -LR
 
       - run: scripts/test.ps1
         shell: pwsh

--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa #2.10.0
-
+        with:
+          flutter-version: '3.13.2'
+          channel: 'stable'
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

On linux an expected file `app.so` is missing in the integration test. Last successful check was with flutter 3.13.2. Check if the flutter version was the culprit.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
