### PR TITLE
Add option to provide alternative binary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add option to provide alternative binary directory ([#214](https://github.com/getsentry/sentry-dart-plugin/pull/214))
+
 ## 1.7.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ ignore_missing=true
 | web_build_path | The web build folder | default: build/web (string)  | no | - |
 | commits | Release commits integration | default: auto | no | - |
 | ignore_missing | Ignore missing commits previously used in the release | default: false | no | - |
+| bin_dir | The folder where the plugin downloads the sentry-cli binary | .dart_tool/pub/bin/sentry_dart_plugin (string) | no | - |
 
 ## Troubleshooting
 

--- a/lib/src/cli/setup.dart
+++ b/lib/src/cli/setup.dart
@@ -10,12 +10,11 @@ import 'sources.dart';
 
 class CLISetup {
   final /*CLISources*/ Map<HostPlatform, CLISource> _sources;
-  final _directory = '.dart_tool/pub/bin/sentry_dart_plugin';
 
   CLISetup(this._sources);
 
-  Future<String> download(HostPlatform platform) async {
-    final dir = injector.get<FileSystem>().directory(_directory);
+  Future<String> download(HostPlatform platform, String directory) async {
+    final dir = injector.get<FileSystem>().directory(directory);
     await dir.create(recursive: true);
     final file = dir.childFile('sentry-cli${platform.executableExtension}');
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -130,7 +130,8 @@ class Configuration {
         reader.getString('auth_token'); // or env. var. SENTRY_AUTH_TOKEN
     url = reader.getString('url'); // or env. var. SENTRY_URL
     logLevel = reader.getString('log_level'); // or env. var. SENTRY_LOG_LEVEL
-    binDir = reader.getString('bin_dir') ?? '.dart_tool/pub/bin/sentry_dart_plugin';
+    binDir =
+        reader.getString('bin_dir') ?? '.dart_tool/pub/bin/sentry_dart_plugin';
   }
 
   /// Validates the configuration values and log an error if required fields

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -80,14 +80,19 @@ class Configuration {
   /// https://docs.sentry.io/product/cli/releases/#dealing-with-missing-commits
   late bool ignoreMissing;
 
+  /// The directory where the sentry-cli binary is downloaded to. Defaults to
+  /// `.dart_tool/pub/bin/sentry_dart_plugin`.
+  late String binDir;
+
   /// Loads the configuration values
   Future<void> getConfigValues(List<String> arguments) async {
     const taskName = 'reading config values';
     Log.startingTask(taskName);
-    await _findAndSetCliPath();
 
     final reader = ConfigReader();
     loadConfig(reader);
+
+    await _findAndSetCliPath();
 
     Log.taskCompleted(taskName);
   }
@@ -125,6 +130,7 @@ class Configuration {
         reader.getString('auth_token'); // or env. var. SENTRY_AUTH_TOKEN
     url = reader.getString('url'); // or env. var. SENTRY_URL
     logLevel = reader.getString('log_level'); // or env. var. SENTRY_LOG_LEVEL
+    binDir = reader.getString('bin_dir') ?? '.dart_tool/pub/bin/sentry_dart_plugin';
   }
 
   /// Validates the configuration values and log an error if required fields
@@ -198,7 +204,7 @@ class Configuration {
     }
 
     try {
-      cliPath = await injector.get<CLISetup>().download(platform);
+      cliPath = await injector.get<CLISetup>().download(platform, binDir);
     } on Exception catch (e) {
       Log.error("Failed to download Sentry CLI: $e");
       return _setPreInstalledCli();

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -16,7 +16,8 @@ void main() {
       final fs = MemoryFileSystem.test();
       injector.registerSingleton<FileSystem>(() => fs, override: true);
       final cliSetup = CLISetup(sources);
-      final file = await cliSetup.download(platform, '.dart_tool/pub/bin/sentry_dart_plugin');
+      final file = await cliSetup.download(
+          platform, '.dart_tool/pub/bin/sentry_dart_plugin');
       final suffix = platform.name.startsWith('windows') ? '.exe' : '';
       expect(file, '.dart_tool/pub/bin/sentry_dart_plugin/sentry-cli$suffix');
       expect(fs.file(file).existsSync(), isTrue);

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -16,7 +16,7 @@ void main() {
       final fs = MemoryFileSystem.test();
       injector.registerSingleton<FileSystem>(() => fs, override: true);
       final cliSetup = CLISetup(sources);
-      final file = await cliSetup.download(platform);
+      final file = await cliSetup.download(platform, '.dart_tool/pub/bin/sentry_dart_plugin');
       final suffix = platform.name.startsWith('windows') ? '.exe' : '';
       expect(file, '.dart_tool/pub/bin/sentry_dart_plugin/sentry-cli$suffix');
       expect(fs.file(file).existsSync(), isTrue);

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -273,5 +273,6 @@ class MockCLI implements CLISetup {
   static const name = 'mock-cli';
 
   @override
-  Future<String> download(HostPlatform platform) => Future.value(name);
+  Future<String> download(HostPlatform platform, String directory) =>
+      Future.value(name);
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add the option to provide an alternative download directory for sentry-cli binary

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #151

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
