### PR TITLE
Custom `dist` overrides version build number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Custom `dist` overrides version build number ([#216](https://github.com/getsentry/sentry-dart-plugin/pull/216))
+  - For instance, if the initial release version is `release@1.0.0+1`, specifying a custom dist value of 2 will update the version to `release@1.0.0+2`.
 
 ## 1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Custom `dist` overrides version build number ([#216](https://github.com/getsentry/sentry-dart-plugin/pull/216))
+
 ## 1.7.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ flutter packages pub run sentry_dart_plugin
 ## Configuration (Optional)
 
 This tool comes with a default configuration. You can configure it to suit your needs.
+By default the plugin will look for the Sentry configuration in the `pubspec.yaml` file.
+If the configuration doesn't exist, the plugin will look for a `sentry.properties` file.
+If the `sentry.properties` file doesn't exist, the plugin will look for environment variables.
+
+### pubspec.yaml
 
 Add `sentry:` configuration at the end of your `pubspec.yaml` file:
 
@@ -57,6 +62,27 @@ sentry:
   web_build_path: ...
   commits: auto
   ignore_missing: true
+```
+
+### sentry.properties
+
+Create a `sentry.properties` file at the root of your project:
+
+```properties
+upload_debug_symbols=true
+upload_source_maps=false
+upload_sources=false
+project=...
+org=...
+auth_token=...
+url=...
+wait_for_processing=false
+log_level=error # possible values: trace, debug, info, warn, error
+release=...
+dist=...
+web_build_path=...
+commits=auto
+ignore_missing=true
 ```
 
 ### Available Configuration Fields

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -230,8 +230,15 @@ class SentryDartPlugin {
     }
 
     final dist = _dist;
-    if (!release.contains('+') && (dist?.isNotEmpty ?? false)) {
-      release += '+${dist!}';
+    if ((dist?.isNotEmpty ?? false)) {
+      if (!release.contains('+')) {
+        release += '+${dist!}';
+      } else {
+        final values = release.split('+');
+        if (values.length == 2) {
+          release = '${values.first}+${dist!}';
+        }
+      }
     }
     return release;
   }

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -54,7 +54,7 @@ class Configuration {
   /// If this field has a build number, it has precedence over the [version]'s buid number from pubspec
   late String? release;
 
-  /// The Apps dist/build number, defaults to the build number after the '+' char from [version]'s pubspec or ser via env. var. SENTRY_DIST
+  /// The Apps dist/build number, defaults to the build number after the '+' char from [version]'s pubspec. Override via env. var. SENTRY_DIST
   /// Example, version: 2.0.0+1, in this case the build number is 1
   late String? dist;
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -51,11 +51,11 @@ class Configuration {
   /// The Apps release name, defaults to 'name@version+buildNumber' from pubspec or set via env. var. SENTRY_RELEASE
   /// Example, name: 'my_app', version: 2.0.0+1, in this case the release is my_app@2.0.0+1
   /// This field has precedence over the [name] from pubspec
-  /// If this field has a build number, it has precedence over the [version]'s buid number from pubspec
+  /// If this field has a build number, it has precedence over the [version]'s build number from pubspec
   late String? release;
 
-  /// The Apps dist/build number, defaults to the build number after the '+' char from [version]'s pubspec. Override via env. var. SENTRY_DIST
-  /// Example, version: 2.0.0+1, in this case the build number is 1
+  /// The Apps dist/build number, taken from pubspec dist or SENTRY_DIST env. variable
+  /// If provided, it will override the build number from [version]
   late String? dist;
 
   /// The Apps version, defaults to [version] from pubspec

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -140,19 +140,22 @@ void main() {
         group('custom releases and dists', () {
           test('custom release with a dist in it', () async {
             final dist = 'myDist';
-            final customRelease = 'myRelease@myVersion+$dist';
+            final release = 'myRelease@myVersion+$dist';
+
+            final customDist = 'anotherDist';
+            final customRelease = 'myRelease@myVersion+$customDist';
 
             final commandLog = await runWith('''
       upload_debug_symbols: false
       upload_source_maps: true
-      release: $customRelease
-      dist: anotherDist
+      release: $release
+      dist: $customDist
     ''');
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $customRelease',
-              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
-              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
+              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $customDist',
+              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir --ext dart --dist $customDist',
               '$cli $args releases $orgAndProject set-commits $customRelease --auto',
               '$cli $args releases $orgAndProject finalize $customRelease'
             ]);
@@ -160,13 +163,13 @@ void main() {
 
           test('custom release with a custom dist', () async {
             final dist = 'myDist';
-            final customRelease = 'myRelease@myVersion';
-            final fullRelease = '$customRelease+$dist';
+            final release = 'myRelease@myVersion';
+            final fullRelease = '$release+$dist';
 
             final commandLog = await runWith('''
       upload_debug_symbols: false
       upload_source_maps: true
-      release: $customRelease
+      release: $release
       dist: $dist
     ''');
             final args = commonArgs;

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -138,6 +138,25 @@ void main() {
         });
 
         group('custom releases and dists', () {
+          test('release with build number (dist)', () async {
+            final dist = 'myDist';
+            final release = 'myRelease@myVersion+$dist';
+
+            final commandLog = await runWith('''
+      upload_debug_symbols: false
+      upload_source_maps: true
+      release: $release
+    ''');
+            final args = commonArgs;
+            expect(commandLog, [
+              '$cli $args releases $orgAndProject new $release',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $dist',
+              '$cli $args releases $orgAndProject set-commits $release --auto',
+              '$cli $args releases $orgAndProject finalize $release'
+            ]);
+          });
+
           test('custom release with a dist in it', () async {
             final dist = 'myDist';
             final release = 'myRelease@myVersion+$dist';


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

When a custom `dist` is provided, either though pubspec or env variable, it takes precedence over the versions build number.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #210

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
