### PR TITLE
Update env/config `release` and `dist` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Custom `dist` overrides version build number ([#216](https://github.com/getsentry/sentry-dart-plugin/pull/216))
-- Update config `release` and `dist` behaviour ([#217](https://github.com/getsentry/sentry-dart-plugin/pull/217))
+- Update env/config `release` and `dist` behaviour ([#217](https://github.com/getsentry/sentry-dart-plugin/pull/217))
   - This is a breaking change, please check if the `release` and `dist` values are as you expect them.
 
 ## 1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 
 - Custom `dist` overrides version build number ([#216](https://github.com/getsentry/sentry-dart-plugin/pull/216))
+- Update config `release` and `dist` behaviour ([#217](https://github.com/getsentry/sentry-dart-plugin/pull/217))
+  - This is a breaking change, please check if the `release` and `dist` values are as you expect them.
 
 ## 1.7.1
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ ignore_missing=true
 | commits | Release commits integration | default: auto | no | - |
 | ignore_missing | Ignore missing commits previously used in the release | default: false | no | - |
 
+## Release
+
+Per default, the release is build from pubspec.yaml's name, version & build: `name@version+build`. The build number, if present, is used as the `dist` parameter.
+
+You can override these values by providing a `release` and `dist` through the plugin config, or through environmental values. The latter have precedence over the former.
+A custom `dist` value will also be used as the build number.
+
+If provided, the plugin will take your `release` and `dist` values without further mutating them. Make sure you configure everything as outlined in the [release docs](https://docs.sentry.io/product/cli/releases/) of `sentry-cli`.
+
 ## Troubleshooting
 
 Sentry's `auth_token` requires the `project:releases` or `project:write` scope, See [docs](https://docs.sentry.io/product/cli/dif/#permissions).

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -209,7 +209,11 @@ class SentryDartPlugin {
       params.add(ext);
     }
 
-    if (release.contains('+')) {
+    final configDist = _configuration.dist ?? "";
+    if (configDist.isNotEmpty) {
+      params.add('--dist');
+      params.add(configDist);
+    } else if (release.contains('+')) {
       params.add('--dist');
       final values = release.split('+');
       params.add(values.last);
@@ -217,13 +221,15 @@ class SentryDartPlugin {
   }
 
   String get _release {
+
+    final configurationRelease = _configuration.release ?? "";
+    if (configurationRelease.isNotEmpty) {
+      return configurationRelease;
+    }
+
     var release = '';
 
-    if (_configuration.release?.isNotEmpty ?? false) {
-      release = _configuration.release!;
-    } else {
-      release = _configuration.name;
-    }
+    release = _configuration.name;
 
     if (!release.contains('@')) {
       release += '@${_configuration.version}';

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -221,7 +221,6 @@ class SentryDartPlugin {
   }
 
   String get _release {
-
     final configurationRelease = _configuration.release ?? "";
     if (configurationRelease.isNotEmpty) {
       return configurationRelease;

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -211,6 +211,7 @@ class SentryDartPlugin {
 
     final configDist = _configuration.dist ?? "";
     if (configDist.isNotEmpty) {
+      // Don't mutate dist users provide through env or plugin config.
       params.add('--dist');
       params.add(configDist);
     } else if (release.contains('+')) {
@@ -221,9 +222,10 @@ class SentryDartPlugin {
   }
 
   String get _release {
-    final configurationRelease = _configuration.release ?? "";
-    if (configurationRelease.isNotEmpty) {
-      return configurationRelease;
+    final configRelease = _configuration.release ?? "";
+    if (configRelease.isNotEmpty) {
+      // Don't mutate release users provide through env or plugin config.
+      return configRelease;
     }
 
     var release = '';

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -96,8 +96,18 @@ class Configuration {
     final environments = Platform.environment;
     final pubspec = ConfigReader.getPubspec();
 
-    release = reader.getString('release') ?? environments['SENTRY_RELEASE'];
-    dist = reader.getString('dist') ?? environments['SENTRY_DIST'];
+    String? envRelease = environments['SENTRY_RELEASE'];
+    if (envRelease?.isEmpty ?? false) {
+      envRelease = null;
+    }
+
+    String? envDist = environments['SENTRY_DIST'];
+    if (envDist?.isEmpty ?? false) {
+      envDist = null;
+    }
+
+    release = envRelease ?? reader.getString('release');
+    dist = envDist ?? reader.getString('dist');
     version = pubspec['version'].toString();
     name = pubspec['name'].toString();
 

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -258,7 +258,9 @@ void main() {
             ]);
           });
 
-          test('used from config and overriding build number from pubspec version', () async {
+          test(
+              'used from config and overriding build number from pubspec version',
+              () async {
             const version = '1.0.0';
             const versionWithBuild = '$version+1';
             final configDist = 'configDist';
@@ -304,7 +306,9 @@ void main() {
             ]);
           });
 
-          test('used from config but not replacing build/dist in config release', () async {
+          test(
+              'used from config but not replacing build/dist in config release',
+              () async {
             const version = '1.0.0';
             final configRelease = 'fixture-configRelease+configDist';
             final configDist = 'configDist';

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -23,10 +23,7 @@ void main() {
 
   const cli = MockCLI.name;
   const orgAndProject = '--org o --project p';
-
-  const project = 'project';
-  const version = '1.1.0';
-
+  const name = 'name';
   const buildDir = '/subdir';
 
   /// File types from which we can read configs.
@@ -43,7 +40,7 @@ void main() {
     fs.currentDirectory = fs.directory(buildDir)..createSync();
     injector.registerSingleton<FileSystem>(() => fs, override: true);
     injector.registerSingleton<CLISetup>(() => MockCLI(), override: true);
-    configWriter = ConfigWriter(fs, project, version);
+    configWriter = ConfigWriter(fs, name);
   });
 
   for (final url in const ['http://127.0.0.1', null]) {
@@ -56,10 +53,10 @@ void main() {
           '$cli help'
         ];
 
-        Future<Iterable<String>> runWith(String config) async {
+        Future<Iterable<String>> runWith(String version, String config) async {
           final formattedConfig =
               ConfigFormatter.formatConfig(config, fileType, url);
-          configWriter.write(fileType, formattedConfig);
+          configWriter.write(version, fileType, formattedConfig);
 
           final exitCode = await plugin.run([]);
           expect(exitCode, 0);
@@ -68,6 +65,7 @@ void main() {
         }
 
         test('works with all configuration files', () async {
+          const version = '1.0.0';
           final config = '''
             upload_debug_symbols: true
             upload_sources: true
@@ -75,8 +73,8 @@ void main() {
             log_level: debug
             ignore_missing: true
           ''';
-          final commandLog = await runWith(config);
-          const release = '$project@$version';
+          final commandLog = await runWith(version, config);
+          const release = '$name@$version';
 
           final args = '$commonArgs --log-level debug';
           expect(commandLog, [
@@ -96,8 +94,9 @@ void main() {
         });
 
         test('defaults', () async {
-          final commandLog = await runWith('');
-          const release = '$project@$version';
+          const version = '1.0.0';
+          final commandLog = await runWith(version, '');
+          const release = '$name@$version';
 
           expect(commandLog, [
             '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
@@ -117,13 +116,15 @@ void main() {
             'repo_name@293ea41d67225d27a8c212f901637e771d73c0f7..1e248e5e6c24b79a5c46a2e8be12cef0e41bd58d',
           ]) {
             test(value, () async {
-              final commandLog =
-                  await runWith(value == null ? '' : 'commits: $value');
+              const version = '1.0.0';
+              final config = value == null ? '' : 'commits: $value';
+              final commandLog = await runWith(version, config);
               final expectedArgs =
                   (value == null || value == 'auto' || value == 'true')
                       ? '--auto'
                       : '--commit $value';
-              const release = '$project@$version';
+
+              const release = '$name@$version';
 
               expect(commandLog, [
                 '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
@@ -136,8 +137,9 @@ void main() {
 
           // if explicitly disabled
           test('false', () async {
-            final commandLog = await runWith('commits: false');
-            const release = '$project@$version';
+            const version = '1.0.0';
+            final commandLog = await runWith(version, 'commits: false');
+            const release = '$name@$version';
 
             expect(commandLog, [
               '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
@@ -147,95 +149,181 @@ void main() {
           });
         });
 
-        group('custom releases and dists', () {
-          test('release with build number (dist)', () async {
-            final dist = 'myDist';
-            final release = 'myRelease@myVersion+$dist';
+        group('release', () {
+          test('default from name and version', () async {
+            const version = '1.0.0';
+            final release = '$name@$version';
 
             final config = '''
               upload_debug_symbols: false
               upload_source_maps: true
-              release: $release
             ''';
-            final commandLog = await runWith(config);
+            final commandLog = await runWith(version, config);
 
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $dist',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart',
               '$cli $args releases $orgAndProject set-commits $release --auto',
               '$cli $args releases $orgAndProject finalize $release'
             ]);
           });
 
-          test('custom release with a dist in it', () async {
-            final dist = 'myDist';
-            final release = 'myRelease@myVersion+$dist';
-
-            final customDist = 'anotherDist';
-            final customRelease = 'myRelease@myVersion+$customDist';
+          test('release from config overrides default', () async {
+            const version = '1.0.0';
+            final configRelease = 'fixture-configRelease';
 
             final config = '''
               upload_debug_symbols: false
               upload_source_maps: true
-              release: $release
-              dist: $customDist
+              release: $configRelease
             ''';
-            final commandLog = await runWith(config);
+            final commandLog = await runWith(version, config);
 
             final args = commonArgs;
             expect(commandLog, [
-              '$cli $args releases $orgAndProject new $customRelease',
-              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $customDist',
-              '$cli $args releases $orgAndProject files $customRelease upload-sourcemaps $buildDir --ext dart --dist $customDist',
-              '$cli $args releases $orgAndProject set-commits $customRelease --auto',
-              '$cli $args releases $orgAndProject finalize $customRelease'
+              '$cli $args releases $orgAndProject new $configRelease',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart',
+              '$cli $args releases $orgAndProject set-commits $configRelease --auto',
+              '$cli $args releases $orgAndProject finalize $configRelease'
+            ]);
+          });
+        });
+
+        group('dist', () {
+          test('read from pubspec version', () async {
+            const build = '1';
+            const versionWithBuild = '1.0.0+$build';
+            final release = '$name@$versionWithBuild';
+
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+            ''';
+            final commandLog = await runWith(versionWithBuild, config);
+
+            final args = commonArgs;
+            expect(commandLog, [
+              '$cli $args releases $orgAndProject new $release',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $build',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $build',
+              '$cli $args releases $orgAndProject set-commits $release --auto',
+              '$cli $args releases $orgAndProject finalize $release'
             ]);
           });
 
-          test('custom release with a custom dist', () async {
-            final dist = 'myDist';
-            final release = 'myRelease@myVersion';
-            final fullRelease = '$release+$dist';
+          test('read from config release', () async {
+            const version = '1.0.0';
+            const build = '1';
+            final configRelease = 'custom+$build';
 
             final config = '''
               upload_debug_symbols: false
               upload_source_maps: true
-              release: $release
-              dist: $dist
+              release: $configRelease
             ''';
-            final commandLog = await runWith(config);
+            final commandLog = await runWith(version, config);
 
             final args = commonArgs;
             expect(commandLog, [
-              '$cli $args releases $orgAndProject new $fullRelease',
-              '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
-              '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
-              '$cli $args releases $orgAndProject set-commits $fullRelease --auto',
-              '$cli $args releases $orgAndProject finalize $fullRelease'
+              '$cli $args releases $orgAndProject new $configRelease',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $build',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $build',
+              '$cli $args releases $orgAndProject set-commits $configRelease --auto',
+              '$cli $args releases $orgAndProject finalize $configRelease'
             ]);
           });
 
-          test('custom dist', () async {
-            final dist = 'myDist';
-            const release = '$project@$version';
-            final fullRelease = '$release+$dist';
+          test('used from config and appended to release', () async {
+            const version = '1.0.0';
+            final configDist = 'configDist';
+            final release = '$name@$version+$configDist';
 
             final config = '''
               upload_debug_symbols: false
               upload_source_maps: true
-              dist: $dist
+              dist: $configDist
             ''';
-            final commandLog = await runWith(config);
+            final commandLog = await runWith(version, config);
 
             final args = commonArgs;
             expect(commandLog, [
-              '$cli $args releases $orgAndProject new $fullRelease',
-              '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $dist',
-              '$cli $args releases $orgAndProject files $fullRelease upload-sourcemaps $buildDir --ext dart --dist $dist',
-              '$cli $args releases $orgAndProject set-commits $fullRelease --auto',
-              '$cli $args releases $orgAndProject finalize $fullRelease'
+              '$cli $args releases $orgAndProject new $release',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $configDist',
+              '$cli $args releases $orgAndProject set-commits $release --auto',
+              '$cli $args releases $orgAndProject finalize $release'
+            ]);
+          });
+
+          test('used from config and overriding build number from pubspec version', () async {
+            const version = '1.0.0';
+            const versionWithBuild = '$version+1';
+            final configDist = 'configDist';
+            final release = '$name@$version+$configDist';
+
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              dist: $configDist
+            ''';
+            final commandLog = await runWith(versionWithBuild, config);
+
+            final args = commonArgs;
+            expect(commandLog, [
+              '$cli $args releases $orgAndProject new $release',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
+              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $configDist',
+              '$cli $args releases $orgAndProject set-commits $release --auto',
+              '$cli $args releases $orgAndProject finalize $release'
+            ]);
+          });
+
+          test('used from config but not appended to config release', () async {
+            const version = '1.0.0';
+            final configRelease = 'fixture-configRelease';
+            final configDist = 'configDist';
+
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              release: $configRelease
+              dist: $configDist
+            ''';
+            final commandLog = await runWith(version, config);
+
+            final args = commonArgs;
+            expect(commandLog, [
+              '$cli $args releases $orgAndProject new $configRelease',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $configDist',
+              '$cli $args releases $orgAndProject set-commits $configRelease --auto',
+              '$cli $args releases $orgAndProject finalize $configRelease'
+            ]);
+          });
+
+          test('used from config but not replacing build/dist in config release', () async {
+            const version = '1.0.0';
+            final configRelease = 'fixture-configRelease+configDist';
+            final configDist = 'configDist';
+
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              release: $configRelease
+              dist: $configDist
+            ''';
+            final commandLog = await runWith(version, config);
+
+            final args = commonArgs;
+            expect(commandLog, [
+              '$cli $args releases $orgAndProject new $configRelease',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
+              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $configDist',
+              '$cli $args releases $orgAndProject set-commits $configRelease --auto',
+              '$cli $args releases $orgAndProject finalize $configRelease'
             ]);
           });
         });

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -23,9 +23,10 @@ void main() {
 
   const cli = MockCLI.name;
   const orgAndProject = '--org o --project p';
+
   const project = 'project';
   const version = '1.1.0';
-  const release = '$project@$version';
+
   const buildDir = '/subdir';
 
   /// File types from which we can read configs.
@@ -67,13 +68,16 @@ void main() {
         }
 
         test('works with all configuration files', () async {
-          final commandLog = await runWith('''
-      upload_debug_symbols: true
-      upload_sources: true
-      upload_source_maps: true
-      log_level: debug
-      ignore_missing: true
-    ''');
+          final config = '''
+            upload_debug_symbols: true
+            upload_sources: true
+            upload_source_maps: true
+            log_level: debug
+            ignore_missing: true
+          ''';
+          final commandLog = await runWith(config);
+          const release = '$project@$version';
+
           final args = '$commonArgs --log-level debug';
           expect(commandLog, [
             '$cli $args debug-files upload $orgAndProject --include-sources $buildDir',
@@ -93,6 +97,8 @@ void main() {
 
         test('defaults', () async {
           final commandLog = await runWith('');
+          const release = '$project@$version';
+
           expect(commandLog, [
             '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
             '$cli $commonArgs releases $orgAndProject new $release',
@@ -117,6 +123,8 @@ void main() {
                   (value == null || value == 'auto' || value == 'true')
                       ? '--auto'
                       : '--commit $value';
+              const release = '$project@$version';
+
               expect(commandLog, [
                 '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
                 '$cli $commonArgs releases $orgAndProject new $release',
@@ -129,6 +137,8 @@ void main() {
           // if explicitly disabled
           test('false', () async {
             final commandLog = await runWith('commits: false');
+            const release = '$project@$version';
+
             expect(commandLog, [
               '$cli $commonArgs debug-files upload $orgAndProject $buildDir',
               '$cli $commonArgs releases $orgAndProject new $release',
@@ -142,11 +152,13 @@ void main() {
             final dist = 'myDist';
             final release = 'myRelease@myVersion+$dist';
 
-            final commandLog = await runWith('''
-      upload_debug_symbols: false
-      upload_source_maps: true
-      release: $release
-    ''');
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              release: $release
+            ''';
+            final commandLog = await runWith(config);
+
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
@@ -164,12 +176,14 @@ void main() {
             final customDist = 'anotherDist';
             final customRelease = 'myRelease@myVersion+$customDist';
 
-            final commandLog = await runWith('''
-      upload_debug_symbols: false
-      upload_source_maps: true
-      release: $release
-      dist: $customDist
-    ''');
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              release: $release
+              dist: $customDist
+            ''';
+            final commandLog = await runWith(config);
+
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $customRelease',
@@ -185,12 +199,14 @@ void main() {
             final release = 'myRelease@myVersion';
             final fullRelease = '$release+$dist';
 
-            final commandLog = await runWith('''
-      upload_debug_symbols: false
-      upload_source_maps: true
-      release: $release
-      dist: $dist
-    ''');
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              release: $release
+              dist: $dist
+            ''';
+            final commandLog = await runWith(config);
+
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $fullRelease',
@@ -203,13 +219,16 @@ void main() {
 
           test('custom dist', () async {
             final dist = 'myDist';
+            const release = '$project@$version';
             final fullRelease = '$release+$dist';
 
-            final commandLog = await runWith('''
-      upload_debug_symbols: false
-      upload_source_maps: true
-      dist: $dist
-    ''');
+            final config = '''
+              upload_debug_symbols: false
+              upload_source_maps: true
+              dist: $dist
+            ''';
+            final commandLog = await runWith(config);
+
             final args = commonArgs;
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $fullRelease',

--- a/test/utils/config_writer.dart
+++ b/test/utils/config_writer.dart
@@ -4,15 +4,14 @@ import 'config_file_type.dart';
 
 class ConfigWriter {
   final FileSystem fs;
-  final String project;
-  final String version;
+  final String name;
 
-  ConfigWriter(this.fs, this.project, this.version);
+  ConfigWriter(this.fs, this.name);
 
-  void write(ConfigFileType configFile, String config) {
+  void write(String version, ConfigFileType configFile, String config) {
     // Write the basic options to pubspec.yaml which is needed for all configs
     fs.file('pubspec.yaml').writeAsStringSync('''
-name: $project
+name: $name
 version: $version
 ''');
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

**Default Release**

- Per default, the release is build from `pubspec.yaml`'s name & version: `name@version`
- If a build number is present in `version`, it is used as `dist`

**Providing custom `release` from env. variable or plugin config**

- It is used as `release` and is not mutated any further

**Providing custom `dist` from env. variable or plugin config**

- It's used as `dist` and is not mutated any further
- It's added as or replacing the build number in default release

**Env Variables**

- `SENTRY_RELEASE` and `SENTRY_DIST` have precedence over values from plugin `config`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #207

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [ ] No breaking changes
