### PR TITLE
Add supported platforms to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,3 +23,8 @@ dependencies:
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.21.6
+
+platforms:
+  linux:
+  windows:
+  macos:


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Since this is a dev_dependency, supported platforms should only be `macos`, 'linux' & 'windows'. Others do this as well, but not all.

Examples:

https://pub.dev/packages/build_runner
https://pub.dev/packages/flutter_lints

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/getsentry/sentry-dart/issues/1952

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

