### PR TITLE
Add `sentry.properties` only setup test

### DIFF
--- a/lib/src/cli/_sources.dart
+++ b/lib/src/cli/_sources.dart
@@ -20,7 +20,8 @@ final currentCLISources = {
   HostPlatform.linuxArmv7: CLISource(
     'sentry-cli-Linux-armv7',
     _version,
-    '1a0bb1d6a8b79a07ac2c839d26d696d59c19b80b236ed85cc5ee118e8047e5b0'),
+    '1a0bb1d6a8b79a07ac2c839d26d696d59c19b80b236ed85cc5ee118e8047e5b0',
+  ),
   HostPlatform.linux64bit: CLISource(
     'sentry-cli-Linux-x86_64',
     _version,

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -113,9 +113,9 @@ class Configuration {
   }
 
   void loadConfig({
-    required ConfigurationValues platformEnvConfig,
     required ConfigurationValues argsConfig,
     required ConfigurationValues fileConfig,
+    required ConfigurationValues platformEnvConfig,
   }) {
     final pubspec = ConfigReader.getPubspec();
 

--- a/lib/src/configuration_values.dart
+++ b/lib/src/configuration_values.dart
@@ -101,7 +101,6 @@ class ConfigurationValues {
     return ConfigurationValues(
       version: configReader.getString('version'),
       name: configReader.getString('name'),
-
       uploadDebugSymbols: configReader.getBool(
         'upload_debug_symbols',
         deprecatedKey: 'upload_native_symbols',

--- a/test/configureation_values_test.dart
+++ b/test/configureation_values_test.dart
@@ -14,8 +14,8 @@ void main() {
   group('ctor', () {
     test("fromArguments", () {
       final arguments = [
-        "--sentry-define=version=fixture-version",
-        "--sentry-define=name=fixture-name",
+        "--sentry-define=version=fixture-sentry-version",
+        "--sentry-define=name=fixture-sentry-name",
         "--sentry-define=upload_debug_symbols=true",
         "--sentry-define=upload_source_maps=true",
         "--sentry-define=upload_sources=true",
@@ -35,9 +35,8 @@ void main() {
         "--sentry-define=sentry_cli_cdn_url=fixture-sentry_cli_cdn_url",
       ];
       final sut = ConfigurationValues.fromArguments(arguments);
-      expect(sut.name, 'fixture-name');
-      expect(sut.version, 'fixture-version');
-
+      expect(sut.name, 'fixture-sentry-name');
+      expect(sut.version, 'fixture-sentry-version');
       expect(sut.uploadDebugSymbols, true);
       expect(sut.uploadSourceMaps, true);
       expect(sut.uploadSources, true);
@@ -77,11 +76,10 @@ void main() {
       expect(sut.name, 'fixture=name');
     });
 
-    test('from config reader', () {
-      final config = '''
-      name: fixture-name
-      version: fixture-version
-      
+    test('from config reader as pubspec', () {
+      final sentryPubspec = '''
+      version: fixture-sentry-version
+      name: fixture-sentry-name      
       upload_debug_symbols: true
       upload_source_maps: true
       upload_sources: true
@@ -103,7 +101,7 @@ void main() {
       injector.registerSingleton<FileSystem>(() => fs, override: true);
 
       final pubspecConfig = ConfigFormatter.formatConfig(
-        config,
+        sentryPubspec,
         ConfigFileType.pubspecYaml,
         null,
       );
@@ -116,9 +114,69 @@ void main() {
 
       final reader = ConfigReader();
       final sut = ConfigurationValues.fromReader(reader);
-      expect(sut.name, 'fixture-name');
-      expect(sut.version, 'fixture-version');
 
+      expect(sut.version, 'fixture-sentry-version');
+      expect(sut.name, 'fixture-sentry-name');
+      expect(sut.uploadDebugSymbols, true);
+      expect(sut.uploadSourceMaps, true);
+      expect(sut.uploadSources, true);
+      expect(sut.project, 'p');
+      expect(sut.org, 'o');
+      expect(sut.authToken, 't');
+      expect(sut.url, 'fixture-url');
+      expect(sut.waitForProcessing, true);
+      expect(sut.logLevel, 'fixture-log_level');
+      expect(sut.release, 'fixture-release');
+      expect(sut.dist, 'fixture-dist');
+      expect(sut.buildPath, 'fixture-build_path');
+      expect(sut.webBuildPath, 'fixture-web_build_path');
+      expect(sut.commits, 'fixture-commits');
+      expect(sut.ignoreMissing, true);
+      expect(sut.binDir, 'fixture-bin_dir');
+      expect(sut.sentryCliCdnUrl, 'fixture-sentry_cli_cdn_url');
+    });
+
+    test('from config reader as properties', () {
+      final sentryProperties = '''
+      version=fixture-sentry-version
+      name=fixture-sentry-name   
+      upload_debug_symbols=true
+      upload_source_maps=true
+      upload_sources=true
+      url=fixture-url
+      wait_for_processing=true
+      log_level=fixture-log_level
+      release=fixture-release
+      dist=fixture-dist
+      build_path=fixture-build_path
+      web_build_path=fixture-web_build_path
+      commits=fixture-commits
+      ignore_missing=true
+      bin_dir=fixture-bin_dir
+      sentry_cli_cdn_url=fixture-sentry_cli_cdn_url
+      ''';
+
+      FileSystem fs = MemoryFileSystem.test();
+      fs.currentDirectory = fs.directory('/subdir')..createSync();
+      injector.registerSingleton<FileSystem>(() => fs, override: true);
+
+      final propertiesConfig = ConfigFormatter.formatConfig(
+        sentryProperties,
+        ConfigFileType.sentryProperties,
+        null,
+      );
+      final writer = ConfigWriter(
+        fs,
+        'fixture-name',
+      );
+      writer.write(
+          'fixture-version', ConfigFileType.sentryProperties, propertiesConfig);
+
+      final reader = ConfigReader();
+      final sut = ConfigurationValues.fromReader(reader);
+
+      expect(sut.version, 'fixture-sentry-version');
+      expect(sut.name, 'fixture-sentry-name');
       expect(sut.uploadDebugSymbols, true);
       expect(sut.uploadSourceMaps, true);
       expect(sut.uploadSources, true);


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->

Adds a test case for reading from properties only.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #231

## :green_heart: How did you test it?

Added tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
