### PR TITLE
revert sentry-cli to 2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   - This is a breaking change, please check if the `release` and `dist` values are as you expect them.
 - Add option to provide alternative binary directory ([#214](https://github.com/getsentry/sentry-dart-plugin/pull/214))
 
+### Dependencies
+
+- Bump CLI from v2.27.0 to v2.31.0 ([#219](https://github.com/getsentry/sentry-dart-plugin/pull/219))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2310)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.27.0...2.31.0)
+
 ## 1.7.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,14 @@
 
 ## Unreleased
 
-- Support SENTRYCLI_CDNURL env ([#230](https://github.com/getsentry/sentry-dart-plugin/pull/230))
-
 ### Features
 
 - Add support for build files folder parameter ([#235](https://github.com/getsentry/sentry-dart-plugin/pull/235))
+- Support SENTRYCLI_CDNURL env ([#230](https://github.com/getsentry/sentry-dart-plugin/pull/230))
 
-### Dependencies
+### Fixes
 
-- Bump CLI from v2.31.0 to v2.31.2 ([#234](https://github.com/getsentry/sentry-dart-plugin/pull/234))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2312)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.31.0...2.31.2)
+- Revert sentry-cli to v2.27.0 ([#241](https://github.com/getsentry/sentry-dart-plugin/pull/241))
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,6 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2310)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.27.0...2.31.0)
 
-### Dependencies
-
-- Bump CLI from v2.27.0 to v2.31.0 ([#219](https://github.com/getsentry/sentry-dart-plugin/pull/219))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2310)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.27.0...2.31.0)
-
 ## 1.7.1
 
 ### Fixes

--- a/integration-test/lib/main.dart
+++ b/integration-test/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 void main() {
+  // trigger
   runApp(const ProjectApp());
 }
 

--- a/integration-test/lib/main.dart
+++ b/integration-test/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  // trigger
   runApp(const ProjectApp());
 }
 

--- a/lib/src/cli/_sources.dart
+++ b/lib/src/cli/_sources.dart
@@ -4,36 +4,23 @@ import 'package:sentry_dart_plugin/src/cli/sources.dart';
 
 import 'host_platform.dart';
 
-const _version = '2.31.2';
+const _version = '2.27.0';
 
 final currentCLISources = {
   HostPlatform.darwinUniversal: CLISource(
-    'sentry-cli-Darwin-universal',
-    _version,
-    'a8aac1d1821fcd42c75f9e8a4d9abd443d32dafa213f1c515d744de343d1f474',
-  ),
-  HostPlatform.linuxAarch64: CLISource(
-    'sentry-cli-Linux-aarch64',
-    _version,
-    '17f2af78965d67571eb22b49934c4c7f2620a7b8e52c9db4116e73eb9877af88',
-  ),
-  HostPlatform.linuxArmv7: CLISource(
-    'sentry-cli-Linux-armv7',
-    _version,
-    '1a0bb1d6a8b79a07ac2c839d26d696d59c19b80b236ed85cc5ee118e8047e5b0'),
-  HostPlatform.linux64bit: CLISource(
-    'sentry-cli-Linux-x86_64',
-    _version,
-    'a6e82e7c4eac8d4c358bf261badf97f0d2fc7469093082397345cfe99f6caf18',
-  ),
-  HostPlatform.windows32bit: CLISource(
-    'sentry-cli-Windows-i686.exe',
-    _version,
-    '2e5eed2ccf985259503ed8bcb694a258d1b82dfc9ed5b8eca1bbaf0257b95930',
-  ),
+      'sentry-cli-Darwin-universal',
+      _version,
+      '8693527282890285f55d9b55414905e8621dd788ad3ae4c85175b84e8eeb6a04'),
+  HostPlatform.linuxAarch64: CLISource('sentry-cli-Linux-aarch64', _version,
+      '54fce909d18c815cb41a3fd24088b76b58872326f211e18ee28646ae844882b0'),
+  HostPlatform.linuxArmv7: CLISource('sentry-cli-Linux-armv7', _version,
+      '7fbc79ea7d90aa39acf7e0cdd66535258494ef981401ce37c477b42393505b79'),
+  HostPlatform.linux64bit: CLISource('sentry-cli-Linux-x86_64', _version,
+      '6b31bbd385d436620415305c12ae181c38bdd3a54c243803dc3ff241ee952356'),
+  HostPlatform.windows32bit: CLISource('sentry-cli-Windows-i686.exe', _version,
+      'de0fa9d55f7c78f16b712955607979b21f797ba89e08e490a76f07991b272d4d'),
   HostPlatform.windows64bit: CLISource(
-    'sentry-cli-Windows-x86_64.exe',
-    _version,
-    '82a395375f4cf732706f5b8030a9394ab57753f76334d2ae480f5d4f6961a723',
-  ),
+      'sentry-cli-Windows-x86_64.exe',
+      _version,
+      'ff6e8708ef7e95d1358e38ed5dc8bb4e62ebd359aff4749dc336b8d2e48ba5b9'),
 };

--- a/lib/src/cli/_sources.dart
+++ b/lib/src/cli/_sources.dart
@@ -4,23 +4,23 @@ import 'package:sentry_dart_plugin/src/cli/sources.dart';
 
 import 'host_platform.dart';
 
-const _version = '2.31.0';
+const _version = '2.27.0';
 const _urlPrefix = 'https://downloads.sentry-cdn.com/sentry-cli/$_version';
 
 final currentCLISources = {
   HostPlatform.darwinUniversal: CLISource(
       '$_urlPrefix/sentry-cli-Darwin-universal',
-      '5d12bee428d18ca49657f2573b130a0c5990a665e0cbe6fad583e72a2fd1e3cc'),
+      '8693527282890285f55d9b55414905e8621dd788ad3ae4c85175b84e8eeb6a04'),
   HostPlatform.linuxAarch64: CLISource('$_urlPrefix/sentry-cli-Linux-aarch64',
-      '2b92198d58ffd2f4551db6782b42b42ecc1ba3c7c7864f0c4ae84be940f927d3'),
+      '54fce909d18c815cb41a3fd24088b76b58872326f211e18ee28646ae844882b0'),
   HostPlatform.linuxArmv7: CLISource('$_urlPrefix/sentry-cli-Linux-armv7',
-      '2745bc24c84fa7bf1b2c8331acc5bce8741a329ed3866162c5279296d856b1f6'),
+      '7fbc79ea7d90aa39acf7e0cdd66535258494ef981401ce37c477b42393505b79'),
   HostPlatform.linux64bit: CLISource('$_urlPrefix/sentry-cli-Linux-x86_64',
-      'baeb5b4ca0a5e500d667087f0b7fbb2865d3b8f01896cfba5144433dbe59bebd'),
+      '6b31bbd385d436620415305c12ae181c38bdd3a54c243803dc3ff241ee952356'),
   HostPlatform.windows32bit: CLISource(
       '$_urlPrefix/sentry-cli-Windows-i686.exe',
-      '5620bd8d7ce13dfa489d45fab2c6c421ee0570c8217e7c3fbbddae38c910bba5'),
+      'de0fa9d55f7c78f16b712955607979b21f797ba89e08e490a76f07991b272d4d'),
   HostPlatform.windows64bit: CLISource(
       '$_urlPrefix/sentry-cli-Windows-x86_64.exe',
-      'de063e8f5ab9e8e8642f7316dec5b5bb7f856dd4ac2cb1a1b58149e2e9d31758'),
+      'ff6e8708ef7e95d1358e38ed5dc8bb4e62ebd359aff4749dc336b8d2e48ba5b9'),
 };

--- a/lib/src/cli/_sources.dart
+++ b/lib/src/cli/_sources.dart
@@ -4,23 +4,23 @@ import 'package:sentry_dart_plugin/src/cli/sources.dart';
 
 import 'host_platform.dart';
 
-const _version = '2.27.0';
+const _version = '2.31.0';
 const _urlPrefix = 'https://downloads.sentry-cdn.com/sentry-cli/$_version';
 
 final currentCLISources = {
   HostPlatform.darwinUniversal: CLISource(
       '$_urlPrefix/sentry-cli-Darwin-universal',
-      '8693527282890285f55d9b55414905e8621dd788ad3ae4c85175b84e8eeb6a04'),
+      '5d12bee428d18ca49657f2573b130a0c5990a665e0cbe6fad583e72a2fd1e3cc'),
   HostPlatform.linuxAarch64: CLISource('$_urlPrefix/sentry-cli-Linux-aarch64',
-      '54fce909d18c815cb41a3fd24088b76b58872326f211e18ee28646ae844882b0'),
+      '2b92198d58ffd2f4551db6782b42b42ecc1ba3c7c7864f0c4ae84be940f927d3'),
   HostPlatform.linuxArmv7: CLISource('$_urlPrefix/sentry-cli-Linux-armv7',
-      '7fbc79ea7d90aa39acf7e0cdd66535258494ef981401ce37c477b42393505b79'),
+      '2745bc24c84fa7bf1b2c8331acc5bce8741a329ed3866162c5279296d856b1f6'),
   HostPlatform.linux64bit: CLISource('$_urlPrefix/sentry-cli-Linux-x86_64',
-      '6b31bbd385d436620415305c12ae181c38bdd3a54c243803dc3ff241ee952356'),
+      'baeb5b4ca0a5e500d667087f0b7fbb2865d3b8f01896cfba5144433dbe59bebd'),
   HostPlatform.windows32bit: CLISource(
       '$_urlPrefix/sentry-cli-Windows-i686.exe',
-      'de0fa9d55f7c78f16b712955607979b21f797ba89e08e490a76f07991b272d4d'),
+      '5620bd8d7ce13dfa489d45fab2c6c421ee0570c8217e7c3fbbddae38c910bba5'),
   HostPlatform.windows64bit: CLISource(
       '$_urlPrefix/sentry-cli-Windows-x86_64.exe',
-      'ff6e8708ef7e95d1358e38ed5dc8bb4e62ebd359aff4749dc336b8d2e48ba5b9'),
+      'de063e8f5ab9e8e8642f7316dec5b5bb7f856dd4ac2cb1a1b58149e2e9d31758'),
 };


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Revert sentry-cli to 2.27.0

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-dart/issues/2048 in v2 of the dart plugin