### PR TITLE
Only upload `.dart` files with `upload-sourcemaps` when `upload_sources` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Only upload `.dart` files with `upload-sourcemaps` when `upload_sources` is enabled ([#247](https://github.com/getsentry/sentry-dart-plugin/pull/247))
+
 ## 2.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Only upload `.dart` files with `upload-sourcemaps` when `upload_sources` is enabled ([#247](https://github.com/getsentry/sentry-dart-plugin/pull/247))
+  - Enable `upload_sources` to opt in to Flutter web source context
 
 ## 2.1.0
 

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -140,17 +140,20 @@ class SentryDartPlugin {
 
     await _executeAndLog('Failed to upload source maps', releaseJsFilesParams);
 
-    // upload source maps (dart)
-    List<String> releaseDartFilesParams = [];
-    releaseDartFilesParams.addAll(params);
 
-    _addExtensionToParams(['dart'], releaseDartFilesParams, release,
-        _configuration.buildFilesFolder);
+    if (_configuration.uploadSources) {
+      // upload source maps (dart)
+      List<String> releaseDartFilesParams = [];
+      releaseDartFilesParams.addAll(params);
 
-    _addWait(releaseDartFilesParams);
+      _addExtensionToParams(['dart'], releaseDartFilesParams, release,
+          _configuration.buildFilesFolder);
 
-    await _executeAndLog(
-        'Failed to upload source maps', releaseDartFilesParams);
+      _addWait(releaseDartFilesParams);
+
+      await _executeAndLog(
+          'Failed to upload source maps', releaseDartFilesParams);
+    }
 
     Log.taskCompleted(taskName);
   }

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -142,7 +142,7 @@ class SentryDartPlugin {
 
 
     if (_configuration.uploadSources) {
-      // upload source maps (dart)
+      // upload source files (dart)
       List<String> releaseDartFilesParams = [];
       releaseDartFilesParams.addAll(params);
 
@@ -152,7 +152,7 @@ class SentryDartPlugin {
       _addWait(releaseDartFilesParams);
 
       await _executeAndLog(
-          'Failed to upload source maps', releaseDartFilesParams);
+          'Failed to upload source files', releaseDartFilesParams);
     }
 
     Log.taskCompleted(taskName);

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -194,7 +194,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
               '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart',
               '$cli $args releases $orgAndProject set-commits $release --auto',
               '$cli $args releases $orgAndProject finalize $release'
             ]);
@@ -215,7 +214,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $configRelease',
               '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js',
-              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart',
               '$cli $args releases $orgAndProject set-commits $configRelease --auto',
               '$cli $args releases $orgAndProject finalize $configRelease'
             ]);
@@ -238,7 +236,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
               '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $build',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $build',
               '$cli $args releases $orgAndProject set-commits $release --auto',
               '$cli $args releases $orgAndProject finalize $release'
             ]);
@@ -260,7 +257,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $configRelease',
               '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $build',
-              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $build',
               '$cli $args releases $orgAndProject set-commits $configRelease --auto',
               '$cli $args releases $orgAndProject finalize $configRelease'
             ]);
@@ -282,7 +278,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
               '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $configDist',
               '$cli $args releases $orgAndProject set-commits $release --auto',
               '$cli $args releases $orgAndProject finalize $release'
             ]);
@@ -307,7 +302,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $release',
               '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
-              '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart --dist $configDist',
               '$cli $args releases $orgAndProject set-commits $release --auto',
               '$cli $args releases $orgAndProject finalize $release'
             ]);
@@ -330,7 +324,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $configRelease',
               '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
-              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $configDist',
               '$cli $args releases $orgAndProject set-commits $configRelease --auto',
               '$cli $args releases $orgAndProject finalize $configRelease'
             ]);
@@ -355,7 +348,6 @@ void main() {
             expect(commandLog, [
               '$cli $args releases $orgAndProject new $configRelease',
               '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir/build/web --ext map --ext js --dist $configDist',
-              '$cli $args releases $orgAndProject files $configRelease upload-sourcemaps $buildDir --ext dart --dist $configDist',
               '$cli $args releases $orgAndProject set-commits $configRelease --auto',
               '$cli $args releases $orgAndProject finalize $configRelease'
             ]);


### PR DESCRIPTION
… is enabled

## :scroll: Description
<!--- Describe your changes in detail -->

- Only upload `.dart` files with `upload-sourcemaps` when `upload_sources` is enabled

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #246

## :green_heart: How did you test it?

Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
