### PR TITLE
fix: web source context upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Dart source context on web missing ([#285](https://github.com/getsentry/sentry-dart-plugin/pull/285))
+
 ## 2.2.0
 
 ### Changes

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -220,8 +220,7 @@ class SentryDartPlugin {
       List<String> releaseDartFilesParams = [];
       releaseDartFilesParams.addAll(params);
 
-      _addExtensionToParams(['dart'], releaseDartFilesParams, release,
-          _configuration.buildFilesFolder);
+      _addExtensionToParams(['dart'], releaseDartFilesParams, release, 'lib');
 
       _addWait(releaseDartFilesParams);
 

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -85,7 +85,7 @@ void main() {
             '$cli $args debug-files upload $orgAndProject --include-sources $buildDir/app/outputs',
             '$cli $args releases $orgAndProject new $release',
             '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/web --ext map --ext js',
-            '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir --ext dart',
+            '$cli $args releases $orgAndProject files $release upload-sourcemaps lib --ext dart',
             '$cli $args releases $orgAndProject set-commits $release --auto --ignore-missing',
             '$cli $args releases $orgAndProject finalize $release'
           ]);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes upload of ".dart" files for web apps.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #283

This got broken in #277 
The problem was that `buildFilesFolder` configuration was also used to collect sources. It didn't make sense semantically, but it worked because, conveniently, the folder defaulted to the current directory.

## :green_heart: How did you test it?

with `./run.sh web` in sentry-dart/flutter/example`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
