### PR TITLE
Add missing prefix to source file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add missing prefix to source file upload ([#306](https://github.com/getsentry/sentry-dart-plugin/pull/306))
+
 ## 2.4.0
 
 ### Enhancements

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -214,8 +214,13 @@ class SentryDartPlugin {
     List<String> releaseJsFilesParams = [];
     releaseJsFilesParams.addAll(params);
 
-    _addExtensionToParams(['map', 'js'], releaseJsFilesParams, release,
-        _configuration.webBuildFilesFolder);
+    _addExtensionToParams(
+      ['map', 'js'],
+      releaseJsFilesParams,
+      release,
+      _configuration.webBuildFilesFolder,
+      null,
+    );
 
     _addWait(releaseJsFilesParams);
     _addUrlPrefix(releaseJsFilesParams);
@@ -227,7 +232,13 @@ class SentryDartPlugin {
       List<String> releaseDartFilesParams = [];
       releaseDartFilesParams.addAll(params);
 
-      _addExtensionToParams(['dart'], releaseDartFilesParams, release, 'lib');
+      _addExtensionToParams(
+        ['dart'],
+        releaseDartFilesParams,
+        release,
+        'lib',
+        '~/lib/',
+      );
 
       _addWait(releaseDartFilesParams);
 
@@ -292,8 +303,8 @@ class SentryDartPlugin {
     }
   }
 
-  void _addExtensionToParams(
-      List<String> exts, List<String> params, String release, String folder) {
+  void _addExtensionToParams(List<String> exts, List<String> params,
+      String release, String folder, String? urlPrefix) {
     params.add('files');
     params.add(release);
     params.add('upload-sourcemaps');
@@ -313,6 +324,11 @@ class SentryDartPlugin {
       params.add('--dist');
       final values = release.split('+');
       params.add(values.last);
+    }
+
+    if (urlPrefix != null) {
+      params.add("--url-prefix");
+      params.add(urlPrefix);
     }
   }
 

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -85,7 +85,7 @@ void main() {
             '$cli $args debug-files upload $orgAndProject --include-sources $buildDir/app/outputs',
             '$cli $args releases $orgAndProject new $release',
             '$cli $args releases $orgAndProject files $release upload-sourcemaps $buildDir/web --ext map --ext js',
-            '$cli $args releases $orgAndProject files $release upload-sourcemaps lib --ext dart',
+            '$cli $args releases $orgAndProject files $release upload-sourcemaps lib --ext dart --url-prefix ~/lib/',
             '$cli $args releases $orgAndProject set-commits $release --auto --ignore-missing',
             '$cli $args releases $orgAndProject finalize $release'
           ]);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

The source maps reference sources from the root folder. So when we added `lib` as a folder for sources to upload, we also need to add `lib` as a prefix so the reference is correct.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #299
Closes #304

## :green_heart: How did you test it?

Updated unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes