### PR TITLE
Add additional path to check for ios dsyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add additional path to check for iOS debug symbols ([#342](https://github.com/getsentry/sentry-dart-plugin/pull/342))
+
 ## 3.1.0
 
 ### Features

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -102,7 +102,7 @@ class SentryDartPlugin {
 
   Stream<String> _enumerateDebugSymbolPaths(FileSystem fs) async* {
     final buildDir = _configuration.buildFilesFolder;
-    final String projectRoot = fs.currentDirectory.path;
+    final projectRoot = fs.currentDirectory.path;
 
     // Android (apk, appbundle)
     yield '$buildDir/app/outputs';

--- a/lib/sentry_dart_plugin.dart
+++ b/lib/sentry_dart_plugin.dart
@@ -102,6 +102,7 @@ class SentryDartPlugin {
 
   Stream<String> _enumerateDebugSymbolPaths(FileSystem fs) async* {
     final buildDir = _configuration.buildFilesFolder;
+    final String projectRoot = fs.currentDirectory.path;
 
     // Android (apk, appbundle)
     yield '$buildDir/app/outputs';
@@ -142,6 +143,9 @@ class SentryDartPlugin {
 
     // iOS (ios-framework)
     yield '$buildDir/ios/framework/Release';
+
+    // iOS in Fastlane
+    yield '$projectRoot/ios/build';
   }
 
   Future<Set<String>> _enumerateSymbolFiles() async {

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -406,6 +406,7 @@ void main() {
             const version = '1.0.0';
             final config = 'upload_debug_symbols: true';
 
+            // Default output directories in build/
             final outputDirectories = [
               'app/outputs',
               'app/intermediates',
@@ -420,9 +421,17 @@ void main() {
               'ios/Release-iphoneos',
               'ios/Release-anyrandomflavor-iphoneos',
               'ios/archive',
-              'ios/framework/Release'
+              'ios/framework/Release',
             ];
+            // Alternative output directories from 'root'
+            final alternativeOutputDirectories = ['ios/build'];
             for (final dir in outputDirectories) {
+              fs
+                  .directory(buildDir)
+                  .childDirectory(dir)
+                  .createSync(recursive: true);
+            }
+            for (final dir in alternativeOutputDirectories) {
               fs
                   .directory(buildDir)
                   .childDirectory(dir)
@@ -434,8 +443,10 @@ void main() {
             for (final dir in outputDirectories) {
               expect(
                   commandLog,
-                  contains(
-                      '$cli $commonArgs debug-files upload $orgAndProject $buildDir/$dir'));
+                  contains(anyOf([
+                    '$cli $commonArgs debug-files upload $orgAndProject $buildDir/$dir',
+                    '$cli $commonArgs debug-files upload $orgAndProject $dir'
+                  ])));
             }
           });
         });


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seems like fastlane outputs the dsyms in `root/ios/build`

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
