### PR TITLE
chore(gh): Update add-platform-label.yml

### DIFF
--- a/.github/workflows/add-platform-label.yml
+++ b/.github/workflows/add-platform-label.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 #1.0.4
         with:
-          add-labels: "Platform: Dart"
+          add-labels: "Dart"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
replaces usage of GH platform label to Linear-compatible label

#skip-changelog