### PR TITLE
chore(ci): Migrate danger workflow to v3

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   danger:
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/danger@v3


### PR DESCRIPTION
## Summary

Migrates the Danger workflow from v2 (reusable workflow) to v3 (composite action).

This PR correctly converts the workflow structure from:
```yaml
jobs:
  danger:
    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
```

To:
```yaml
jobs:
  danger:
    runs-on: ubuntu-latest
    steps:
      - uses: getsentry/github-workflows/danger@v3
```

## Benefits

- Latest Danger JS version (v13.0.4)
- Better conventional commit scope handling
- Enhanced support for non-conventional PR titles

Closes #359

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)