### PR TITLE
fix: Add custom symbols_path in iOS symbol map discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Fix processor architecture for Linux ([#355](https://github.com/getsentry/sentry-dart-plugin/pull/355))
+- Add custom `symbols_path` in iOS symbol map discovery ([#394](https://github.com/getsentry/sentry-dart-plugin/pull/394))
 
 ## 3.2.1
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -14,6 +14,8 @@ import 'utils/injector.dart';
 import 'utils/log.dart';
 
 class Configuration {
+  static const String defaultSymbolsFolder = '.';
+
   late final FileSystem _fs = injector.get<FileSystem>();
 
   /// The Build folder, defaults `build`.
@@ -160,7 +162,7 @@ class Configuration {
     // but can be customized so making it flexible.
     final webBuildPath = configValues.webBuildPath ?? 'web';
     webBuildFilesFolder = _fs.path.join(buildFilesFolder, webBuildPath);
-    symbolsFolder = configValues.symbolsPath ?? '.';
+    symbolsFolder = configValues.symbolsPath ?? defaultSymbolsFolder;
     dartSymbolMapPath = configValues.dartSymbolMapPath;
 
     project = configValues.project; // or env. var. SENTRY_PROJECT

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -162,7 +162,10 @@ class Configuration {
     // but can be customized so making it flexible.
     final webBuildPath = configValues.webBuildPath ?? 'web';
     webBuildFilesFolder = _fs.path.join(buildFilesFolder, webBuildPath);
-    symbolsFolder = configValues.symbolsPath ?? defaultSymbolsFolder;
+    final symbolsPath = configValues.symbolsPath;
+    symbolsFolder = symbolsPath == null || symbolsPath.isEmpty
+        ? defaultSymbolsFolder
+        : symbolsPath;
     dartSymbolMapPath = configValues.dartSymbolMapPath;
 
     project = configValues.project; // or env. var. SENTRY_PROJECT

--- a/lib/src/configuration_values.dart
+++ b/lib/src/configuration_values.dart
@@ -113,7 +113,11 @@ class ConfigurationValues {
       legacyWebSymbolication: boolFromString(
         sentryArguments['legacy_web_symbolication'],
       ),
-      ignoreWebSourcePaths: sentryArguments['ignore_web_source_paths']?.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty).toList(),
+      ignoreWebSourcePaths: sentryArguments['ignore_web_source_paths']
+          ?.split(',')
+          .map((e) => e.trim())
+          .where((e) => e.isNotEmpty)
+          .toList(),
     );
   }
 
@@ -217,7 +221,8 @@ class ConfigurationValues {
       sentryCliVersion: args.sentryCliVersion ?? file.sentryCliVersion,
       legacyWebSymbolication:
           args.legacyWebSymbolication ?? file.legacyWebSymbolication,
-      ignoreWebSourcePaths: args.ignoreWebSourcePaths ?? file.ignoreWebSourcePaths,
+      ignoreWebSourcePaths:
+          args.ignoreWebSourcePaths ?? file.ignoreWebSourcePaths,
     );
   }
 }

--- a/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
+++ b/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
@@ -12,9 +12,10 @@ import '../configuration.dart';
 /// - Apple: include the Mach-O binary `App` inside
 ///   `App.framework.dSYM/Contents/Resources/DWARF/App`.
 ///
-/// The function returns absolute, deduplicated paths. It enumerates the
-/// configured `symbolsFolder`, `buildFilesFolder`, and other Flutter
-/// search roots discovered by `enumerateDebugSearchRoots`.
+/// The function returns absolute, deduplicated paths. Android symbols are
+/// discovered under the configured `symbolsFolder`. iOS dSYMs are discovered
+/// under the configured `symbolsFolder` as well as the standard Flutter/Xcode
+/// build roots.
 Future<Set<String>> collectDebugFilesForDartMap({
   required FileSystem fs,
   required Configuration config,
@@ -23,8 +24,9 @@ Future<Set<String>> collectDebugFilesForDartMap({
   final Set<String> foundIosPaths = <String>{};
   final path = fs.path;
   final String normalizedSymbolsFolder = path.normalize(config.symbolsFolder);
-  final bool hasCustomSymbolsFolder = config.symbolsFolder.isNotEmpty &&
-      normalizedSymbolsFolder != Configuration.defaultSymbolsFolder;
+  final bool shouldSearchSymbolsFolderForIos =
+      config.symbolsFolder.isNotEmpty &&
+          normalizedSymbolsFolder != Configuration.defaultSymbolsFolder;
 
   Future<void> collectAndroidSymbolsUnder(String rootPath) async {
     if (rootPath.isEmpty) return;
@@ -45,17 +47,11 @@ Future<Set<String>> collectDebugFilesForDartMap({
     }
   }
 
-  // Prefer scanning Android symbols under the configured symbols folder; if no
-  // custom folder is set, fall back to the default Flutter build locations:
-  // - build/app/outputs
-  // - build/app/intermediates
+  // Android Dart symbol files are written to the configured split-debug-info
+  // directory (symbolsFolder).
   final List<String> androidRoots = <String>[];
-  if (hasCustomSymbolsFolder) {
+  if (config.symbolsFolder.isNotEmpty) {
     androidRoots.add(normalizedSymbolsFolder);
-  } else if (config.buildFilesFolder.isNotEmpty) {
-    final normalizedBuildFolder = path.normalize(config.buildFilesFolder);
-    androidRoots.add(path.join(normalizedBuildFolder, 'app', 'outputs'));
-    androidRoots.add(path.join(normalizedBuildFolder, 'app', 'intermediates'));
   }
 
   for (final String root in androidRoots) {
@@ -63,12 +59,12 @@ Future<Set<String>> collectDebugFilesForDartMap({
   }
 
   if (foundAndroidPaths.isEmpty) {
-    Log.warn(
-        'No Android symbols found in the configured symbols folder or build folder.');
+    Log.warn('No Android symbols found in the configured symbols folder.');
   }
 
-  // Prefer scanning iOS symbols under the configured symbols folder; if not
-  // set, fall back to the default locations used by Flutter/Xcode:
+  // iOS App.framework.dSYM may live either in the configured symbols folder
+  // (for moved/downloaded artifacts) or in the default Flutter/Xcode
+  // locations:
   // - build/ios
   // - <projectRoot>/ios/build (Fastlane)
   final String buildDir = config.buildFilesFolder;
@@ -98,12 +94,11 @@ Future<Set<String>> collectDebugFilesForDartMap({
   }
 
   final List<String> iosRoots = <String>[];
-  if (hasCustomSymbolsFolder) {
+  if (shouldSearchSymbolsFolderForIos) {
     iosRoots.add(normalizedSymbolsFolder);
-  } else {
-    iosRoots.add(path.join(path.normalize(buildDir), 'ios'));
-    iosRoots.add(path.join(projectRoot, 'ios', 'build'));
   }
+  iosRoots.add(path.join(path.normalize(buildDir), 'ios'));
+  iosRoots.add(path.join(projectRoot, 'ios', 'build'));
 
   for (final String root in iosRoots) {
     await collectIosAppDsymsUnderRoot(root);

--- a/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
+++ b/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
@@ -1,6 +1,5 @@
 import 'package:file/file.dart';
 import 'package:sentry_dart_plugin/src/utils/log.dart';
-// import 'package:sentry_dart_plugin/src/utils/flutter_debug_files.dart';
 
 import '../configuration.dart';
 
@@ -23,6 +22,9 @@ Future<Set<String>> collectDebugFilesForDartMap({
   final Set<String> foundAndroidPaths = <String>{};
   final Set<String> foundIosPaths = <String>{};
   final path = fs.path;
+  final String normalizedSymbolsFolder = path.normalize(config.symbolsFolder);
+  final bool hasCustomSymbolsFolder = config.symbolsFolder.isNotEmpty &&
+      normalizedSymbolsFolder != Configuration.defaultSymbolsFolder;
 
   Future<void> collectAndroidSymbolsUnder(String rootPath) async {
     if (rootPath.isEmpty) return;
@@ -43,13 +45,17 @@ Future<Set<String>> collectDebugFilesForDartMap({
     }
   }
 
-  // Prefer scanning Android symbols under the configured symbols folder; if not
-  // set, fall back to the build folder.
+  // Prefer scanning Android symbols under the configured symbols folder; if no
+  // custom folder is set, fall back to the default Flutter build locations:
+  // - build/app/outputs
+  // - build/app/intermediates
   final List<String> androidRoots = <String>[];
-  if (config.symbolsFolder.isNotEmpty) {
-    androidRoots.add(path.normalize(config.symbolsFolder));
+  if (hasCustomSymbolsFolder) {
+    androidRoots.add(normalizedSymbolsFolder);
   } else if (config.buildFilesFolder.isNotEmpty) {
-    androidRoots.add(path.normalize(config.buildFilesFolder));
+    final normalizedBuildFolder = path.normalize(config.buildFilesFolder);
+    androidRoots.add(path.join(normalizedBuildFolder, 'app', 'outputs'));
+    androidRoots.add(path.join(normalizedBuildFolder, 'app', 'intermediates'));
   }
 
   for (final String root in androidRoots) {
@@ -61,7 +67,8 @@ Future<Set<String>> collectDebugFilesForDartMap({
         'No Android symbols found in the configured symbols folder or build folder.');
   }
 
-  // iOS: only search under two roots to simplify discovery:
+  // Prefer scanning iOS symbols under the configured symbols folder; if not
+  // set, fall back to the default locations used by Flutter/Xcode:
   // - build/ios
   // - <projectRoot>/ios/build (Fastlane)
   final String buildDir = config.buildFilesFolder;
@@ -90,12 +97,21 @@ Future<Set<String>> collectDebugFilesForDartMap({
     }
   }
 
-  await collectIosAppDsymsUnderRoot(path.join(path.normalize(buildDir), 'ios'));
-  await collectIosAppDsymsUnderRoot(path.join(projectRoot, 'ios', 'build'));
+  final List<String> iosRoots = <String>[];
+  if (hasCustomSymbolsFolder) {
+    iosRoots.add(normalizedSymbolsFolder);
+  } else {
+    iosRoots.add(path.join(path.normalize(buildDir), 'ios'));
+    iosRoots.add(path.join(projectRoot, 'ios', 'build'));
+  }
+
+  for (final String root in iosRoots) {
+    await collectIosAppDsymsUnderRoot(root);
+  }
 
   if (foundIosPaths.isEmpty) {
     Log.warn(
-        'No iOS symbols found in the configured build folder or project root.');
+        'No iOS symbols found in the configured symbols folder, build folder, or project root.');
   }
 
   return foundAndroidPaths.union(foundIosPaths).toSet();

--- a/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
+++ b/lib/src/symbol_maps/dart_symbol_map_debug_files_collector.dart
@@ -42,7 +42,8 @@ Future<Set<String>> collectDebugFilesForDartMap({
           basename.endsWith('.symbols') &&
           !basename.contains('darwin') &&
           !basename.contains('ios')) {
-        foundAndroidPaths.add(fs.file(entity.path).absolute.path);
+        foundAndroidPaths
+            .add(path.normalize(fs.file(entity.path).absolute.path));
       }
     }
   }

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -254,6 +254,21 @@ void main() {
       expect(sut.legacyWebSymbolication, isFalse);
       expect(sut.ignoreWebSourcePaths, []);
     });
+
+    test("treats empty symbols_path as the default symbols folder", () {
+      final envConfig = ConfigurationValues();
+      final fileConfig = ConfigurationValues();
+      final platformEnvConfig = ConfigurationValues();
+      final argsConfig = ConfigurationValues(symbolsPath: '');
+
+      final sut = fixture.getSut(
+        argsConfig: argsConfig,
+        fileConfig: fileConfig,
+        platformEnvConfig: platformEnvConfig,
+      );
+
+      expect(sut.symbolsFolder, Configuration.defaultSymbolsFolder);
+    });
   });
 }
 

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -256,7 +256,6 @@ void main() {
     });
 
     test("treats empty symbols_path as the default symbols folder", () {
-      final envConfig = ConfigurationValues();
       final fileConfig = ConfigurationValues();
       final platformEnvConfig = ConfigurationValues();
       final argsConfig = ConfigurationValues(symbolsPath: '');

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -240,6 +240,7 @@ void main() {
       expect(sut.commits, 'auto');
       expect(sut.ignoreMissing, isFalse);
       expect(sut.buildFilesFolder, 'build');
+      expect(sut.symbolsFolder, Configuration.defaultSymbolsFolder);
       expect(
         sut.webBuildFilesFolder,
         fixture.fs.path.join(sut.buildFilesFolder, 'web'),

--- a/test/dart_symbol_map_debug_files_collector_test.dart
+++ b/test/dart_symbol_map_debug_files_collector_test.dart
@@ -157,33 +157,6 @@ void main() {
 
     // macOS is not supported for Dart symbol map pairing.
 
-    test('prefers configured symbols path over default Android build roots',
-        () async {
-      final fs = MemoryFileSystem(style: FileSystemStyle.posix);
-      final projectRootDir = fs.directory('/project')
-        ..createSync(recursive: true);
-      fs.currentDirectory = projectRootDir;
-
-      final buildDir = '/project/build';
-      final symbolsDir = '/external-symbols';
-      final symbolsPath = '/external-symbols/app.android-arm64.symbols';
-      final defaultPath = '/project/build/app/outputs/app.android-x64.symbols';
-      fs.file(symbolsPath).createSync(recursive: true);
-      fs.file(defaultPath).createSync(recursive: true);
-
-      final config = Configuration()
-        ..buildFilesFolder = buildDir
-        ..symbolsFolder = symbolsDir;
-
-      final result = await collectDebugFilesForDartMap(
-        fs: fs,
-        config: config,
-      );
-
-      expect(result, contains(fs.path.normalize(symbolsPath)));
-      expect(result, isNot(contains(fs.path.normalize(defaultPath))));
-    });
-
     test('searches symbols path and default iOS build roots', () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/project')

--- a/test/dart_symbol_map_debug_files_collector_test.dart
+++ b/test/dart_symbol_map_debug_files_collector_test.dart
@@ -72,35 +72,30 @@ void main() {
       }
     });
 
-    test('uses focused Android fallback roots for default symbols path',
-        () async {
+    test('uses symbols path for Android symbol discovery', () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/project')
         ..createSync(recursive: true);
       fs.currentDirectory = projectRootDir;
 
       final buildDir = '/project/out';
-      final outputsSymbols = '$buildDir/app/outputs/app.android-arm64.symbols';
-      final intermediatesSymbols =
-          '$buildDir/app/intermediates/app.android-x64.symbols';
-      final unrelatedProjectRootSymbols = '/project/app.android-arm.symbols';
+      final symbolsDir = '/project/build/symbols';
+      final symbolsPath = '$symbolsDir/app.android-arm64.symbols';
+      final outputsSymbols = '$buildDir/app/outputs/app.android-x64.symbols';
+      fs.file(symbolsPath).createSync(recursive: true);
       fs.file(outputsSymbols).createSync(recursive: true);
-      fs.file(intermediatesSymbols).createSync(recursive: true);
-      fs.file(unrelatedProjectRootSymbols).createSync(recursive: true);
 
       final config = Configuration()
         ..buildFilesFolder = buildDir
-        ..symbolsFolder = Configuration.defaultSymbolsFolder;
+        ..symbolsFolder = symbolsDir;
 
       final result = await collectDebugFilesForDartMap(
         fs: fs,
         config: config,
       );
 
-      expect(result, contains(fs.path.normalize(outputsSymbols)));
-      expect(result, contains(fs.path.normalize(intermediatesSymbols)));
-      expect(result,
-          isNot(contains(fs.path.normalize(unrelatedProjectRootSymbols))));
+      expect(result, contains(fs.path.normalize(symbolsPath)));
+      expect(result, isNot(contains(fs.path.normalize(outputsSymbols))));
     });
 
     test('uses focused iOS fallback roots for default symbols path', () async {
@@ -189,8 +184,7 @@ void main() {
       expect(result, isNot(contains(fs.path.normalize(defaultPath))));
     });
 
-    test('prefers configured symbols path over default iOS build roots',
-        () async {
+    test('searches symbols path and default iOS build roots', () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/project')
         ..createSync(recursive: true);
@@ -200,9 +194,12 @@ void main() {
       final symbolsDir = '/external-symbols';
       final symbolsMachO =
           '/external-symbols/App.framework.dSYM/Contents/Resources/DWARF/App';
+      final buildMachO =
+          '/project/build/ios/Release-iphoneos/App.framework.dSYM/Contents/Resources/DWARF/App';
       final fastlaneMachO =
           '/project/ios/build/App.framework.dSYM/Contents/Resources/DWARF/App';
       fs.file(symbolsMachO).createSync(recursive: true);
+      fs.file(buildMachO).createSync(recursive: true);
       fs.file(fastlaneMachO).createSync(recursive: true);
 
       final config = Configuration()
@@ -215,7 +212,8 @@ void main() {
       );
 
       expect(result, contains(fs.path.normalize(symbolsMachO)));
-      expect(result, isNot(contains(fs.path.normalize(fastlaneMachO))));
+      expect(result, contains(fs.path.normalize(buildMachO)));
+      expect(result, contains(fs.path.normalize(fastlaneMachO)));
     });
 
     test('finds App.framework.dSYM inside iOS Xcode archive dSYMs', () async {

--- a/test/dart_symbol_map_debug_files_collector_test.dart
+++ b/test/dart_symbol_map_debug_files_collector_test.dart
@@ -6,7 +6,8 @@ import 'package:sentry_dart_plugin/src/symbol_maps/dart_symbol_map_debug_files_c
 
 void main() {
   group('collectDebugFilesForDartMap', () {
-    test('returns Android .symbols only and Apple App.framework.dSYM Mach-O',
+    test(
+        'returns custom Android and iOS debug files from configured symbols path',
         () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/work')..createSync(recursive: true);
@@ -26,9 +27,9 @@ void main() {
           .file('$symbolsDir/app.android-x64.symbols')
           .createSync(recursive: true);
 
-      // Apple App.framework.dSYM Mach-O
+      // Apple App.framework.dSYM Mach-O under the configured symbols path.
       final appDsymMachO =
-          '$buildDir/ios/iphoneos/App.framework.dSYM/Contents/Resources/DWARF/App';
+          '$symbolsDir/App.framework.dSYM/Contents/Resources/DWARF/App';
       fs.file(appDsymMachO).createSync(recursive: true);
 
       // Noise: other .dSYM bundles should be ignored
@@ -63,7 +64,7 @@ void main() {
       expect(result.any((p) => p.endsWith('/Runner')), isFalse);
       expect(result.any((p) => p.endsWith('/FlutterMacOS')), isFalse);
 
-      // Ensure deduplication and absoluteness
+      // Ensure absoluteness
       expect(result.length, 4);
       for (final p in result) {
         expect(p.startsWith('/'), isTrue,
@@ -71,18 +72,80 @@ void main() {
       }
     });
 
-    test('finds App.framework.dSYM under Fastlane ios/build path', () async {
+    test('uses focused Android fallback roots for default symbols path',
+        () async {
+      final fs = MemoryFileSystem(style: FileSystemStyle.posix);
+      final projectRootDir = fs.directory('/project')
+        ..createSync(recursive: true);
+      fs.currentDirectory = projectRootDir;
+
+      final buildDir = '/project/out';
+      final outputsSymbols = '$buildDir/app/outputs/app.android-arm64.symbols';
+      final intermediatesSymbols =
+          '$buildDir/app/intermediates/app.android-x64.symbols';
+      final unrelatedProjectRootSymbols = '/project/app.android-arm.symbols';
+      fs.file(outputsSymbols).createSync(recursive: true);
+      fs.file(intermediatesSymbols).createSync(recursive: true);
+      fs.file(unrelatedProjectRootSymbols).createSync(recursive: true);
+
+      final config = Configuration()
+        ..buildFilesFolder = buildDir
+        ..symbolsFolder = Configuration.defaultSymbolsFolder;
+
+      final result = await collectDebugFilesForDartMap(
+        fs: fs,
+        config: config,
+      );
+
+      expect(result, contains(fs.path.normalize(outputsSymbols)));
+      expect(result, contains(fs.path.normalize(intermediatesSymbols)));
+      expect(result,
+          isNot(contains(fs.path.normalize(unrelatedProjectRootSymbols))));
+    });
+
+    test('uses focused iOS fallback roots for default symbols path', () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/project')
         ..createSync(recursive: true);
       fs.currentDirectory = projectRootDir;
 
       final buildDir = '/project/build';
-      final symbolsDir = '/project/symbols';
 
       // Fastlane path
       final machO =
           '/project/ios/build/App.framework.dSYM/Contents/Resources/DWARF/App';
+      fs.file(machO).createSync(recursive: true);
+
+      // This should be ignored when using the default symbols path.
+      final unrelatedProjectRootMachO =
+          '/project/App.framework.dSYM/Contents/Resources/DWARF/App';
+      fs.file(unrelatedProjectRootMachO).createSync(recursive: true);
+
+      final config = Configuration()
+        ..buildFilesFolder = buildDir
+        ..symbolsFolder = Configuration.defaultSymbolsFolder;
+
+      final result = await collectDebugFilesForDartMap(
+        fs: fs,
+        config: config,
+      );
+
+      expect(result, contains(fs.path.normalize(machO)));
+      expect(result,
+          isNot(contains(fs.path.normalize(unrelatedProjectRootMachO))));
+    });
+
+    test('finds App.framework.dSYM under configured symbols path', () async {
+      final fs = MemoryFileSystem(style: FileSystemStyle.posix);
+      final projectRootDir = fs.directory('/ci-workspace')
+        ..createSync(recursive: true);
+      fs.currentDirectory = projectRootDir;
+
+      final buildDir = '/ci-workspace/build';
+      final symbolsDir = '/downloaded-symbols';
+
+      final machO =
+          '/downloaded-symbols/App.framework.dSYM/Contents/Resources/DWARF/App';
       fs.file(machO).createSync(recursive: true);
 
       final config = Configuration()
@@ -99,6 +162,62 @@ void main() {
 
     // macOS is not supported for Dart symbol map pairing.
 
+    test('prefers configured symbols path over default Android build roots',
+        () async {
+      final fs = MemoryFileSystem(style: FileSystemStyle.posix);
+      final projectRootDir = fs.directory('/project')
+        ..createSync(recursive: true);
+      fs.currentDirectory = projectRootDir;
+
+      final buildDir = '/project/build';
+      final symbolsDir = '/external-symbols';
+      final symbolsPath = '/external-symbols/app.android-arm64.symbols';
+      final defaultPath = '/project/build/app/outputs/app.android-x64.symbols';
+      fs.file(symbolsPath).createSync(recursive: true);
+      fs.file(defaultPath).createSync(recursive: true);
+
+      final config = Configuration()
+        ..buildFilesFolder = buildDir
+        ..symbolsFolder = symbolsDir;
+
+      final result = await collectDebugFilesForDartMap(
+        fs: fs,
+        config: config,
+      );
+
+      expect(result, contains(fs.path.normalize(symbolsPath)));
+      expect(result, isNot(contains(fs.path.normalize(defaultPath))));
+    });
+
+    test('prefers configured symbols path over default iOS build roots',
+        () async {
+      final fs = MemoryFileSystem(style: FileSystemStyle.posix);
+      final projectRootDir = fs.directory('/project')
+        ..createSync(recursive: true);
+      fs.currentDirectory = projectRootDir;
+
+      final buildDir = '/project/build';
+      final symbolsDir = '/external-symbols';
+      final symbolsMachO =
+          '/external-symbols/App.framework.dSYM/Contents/Resources/DWARF/App';
+      final fastlaneMachO =
+          '/project/ios/build/App.framework.dSYM/Contents/Resources/DWARF/App';
+      fs.file(symbolsMachO).createSync(recursive: true);
+      fs.file(fastlaneMachO).createSync(recursive: true);
+
+      final config = Configuration()
+        ..buildFilesFolder = buildDir
+        ..symbolsFolder = symbolsDir;
+
+      final result = await collectDebugFilesForDartMap(
+        fs: fs,
+        config: config,
+      );
+
+      expect(result, contains(fs.path.normalize(symbolsMachO)));
+      expect(result, isNot(contains(fs.path.normalize(fastlaneMachO))));
+    });
+
     test('finds App.framework.dSYM inside iOS Xcode archive dSYMs', () async {
       final fs = MemoryFileSystem(style: FileSystemStyle.posix);
       final projectRootDir = fs.directory('/iosproj')
@@ -106,7 +225,6 @@ void main() {
       fs.currentDirectory = projectRootDir;
 
       final buildDir = '/iosproj/build';
-      final symbolsDir = '/iosproj/symbols';
 
       // iOS archive path
       final iosArchiveMachO =
@@ -115,7 +233,7 @@ void main() {
 
       final config = Configuration()
         ..buildFilesFolder = buildDir
-        ..symbolsFolder = symbolsDir;
+        ..symbolsFolder = Configuration.defaultSymbolsFolder;
 
       final result = await collectDebugFilesForDartMap(
         fs: fs,

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 const appName = 'testapp';
+const _serverReadyLine = 'INTEGRATION_SERVER_READY';
 late final String serverUri;
 
 // Platforms to be tested are either coming from the CI env var or
@@ -46,11 +47,15 @@ void main() async {
     // Also, we collect the output so that we can check it in tests.
     // Note: we're using the python dummy sever because it was already available.
     // If we wanted, we could do all this in plain dart in the future.
-    testServer = await Process.start('python3', ['test-server.py', serverUri],
-        workingDirectory: '${repoRootDir.path}/test');
+    testServer = await Process.start(
+      'python3',
+      ['-u', 'test-server.py', serverUri],
+      workingDirectory: '${repoRootDir.path}/test',
+    );
 
     // capture & forward streams
     final collector = _ProcessStreamCollector(testServer);
+    await _waitForServerReady(testServer.exitCode, collector);
 
     stopServer = () async {
       await http.get(Uri.parse('$serverUri/STOP'));
@@ -193,6 +198,30 @@ Future<Iterable<String>> _runPlugin(Directory cwd) => _exec(
       cwd: cwd.path,
     );
 
+Future<void> _waitForServerReady(
+    Future<int> exitCode, _ProcessStreamCollector collector) async {
+  int? observedExitCode;
+  unawaited(exitCode.then((value) => observedExitCode = value));
+
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+
+  while (DateTime.now().isBefore(deadline)) {
+    if (collector.outputSoFar.contains(_serverReadyLine)) {
+      return;
+    }
+
+    if (observedExitCode != null) {
+      throw StateError(
+          'Test server exited early with code $observedExitCode.\n${collector.outputSoFar}');
+    }
+
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  throw StateError(
+      'Timed out waiting for test server readiness signal.\n${collector.outputSoFar}');
+}
+
 // e.g. Flutter 3.24.4 • channel stable • https://github.com/flutter/flutter.git
 final _flutterVersionInfo =
     _flutter(['--version']).then((output) => output.first);
@@ -302,6 +331,8 @@ class _ProcessStreamCollector {
     print(str.trim());
     _output.write(str);
   }
+
+  String get outputSoFar => _output.toString();
 
   Future<String> get output =>
       Future.wait(_futures).then((_) => _output.toString());

--- a/test/test-server.py
+++ b/test/test-server.py
@@ -165,11 +165,11 @@ class Handler(BaseHTTPRequestHandler):
         sys.stderr.flush()
 
 
-print("HTTP server listening on {}".format(uri.geturl()))
-print("To stop the server, execute a GET request to {}/STOP".format(uri.geturl()))
-
 try:
     httpd = ThreadingHTTPServer((uri.hostname, uri.port), Handler)
+    print("INTEGRATION_SERVER_READY", flush=True)
+    print("HTTP server listening on {}".format(uri.geturl()), flush=True)
+    print("To stop the server, execute a GET request to {}/STOP".format(uri.geturl()), flush=True)
     target = httpd.serve_forever()
 except KeyboardInterrupt:
     pass


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Flutter produces debug files differently on each platform:
 - Android writes app.android-*.symbols into the configured --split-debug-info / symbols_path directory.
 - iOS keeps App.framework.dSYM/.../App in standard build output paths such as build/ios/...; symbols_path is only relevant there when artifacts have been moved or downloaded in CI.

Update discovery accordingly:
 - Android: Only search the configured symbol directory.
 - iOS: Search both the configured symbol directory and the standard iOS build roots.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #392

## :green_heart: How did you test it?

Unit tests. Checked where ios/android apps put the files.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes