### PR TITLE
fix:  Use SENTRY_URL for Dart symbol map uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Fix processor architecture for Linux ([#355](https://github.com/getsentry/sentry-dart-plugin/pull/355))
+- Use SENTRY_URL for Dart symbol map uploads ([#395](https://github.com/getsentry/sentry-dart-plugin/pull/395))
 
 ## 3.2.1
 

--- a/lib/src/symbol_maps/dart_symbol_map_uploader.dart
+++ b/lib/src/symbol_maps/dart_symbol_map_uploader.dart
@@ -12,9 +12,17 @@ import '../utils/log.dart';
 ///
 /// For every [debugFilePaths] entry, this emits one CLI invocation equivalent to:
 ///
-///   sentry-cli dart-symbol-map upload [--url ...] [--auth-token ...]
-///   [--log-level ...] --org ... --project ... [--wait]
+///   `SENTRY_URL=<custom-url>` sentry-cli dart-symbol-map upload
+///   [--auth-token ...] [--log-level ...] --org ... --project ... [--wait]
 ///   /path-to-map /path-to-debug-file
+///
+/// We pass the custom Sentry URL via `SENTRY_URL` instead of `--url` for
+/// compatibility with older sentry-cli versions that reject `--url` for the
+/// `dart-symbol-map upload` subcommand.
+///
+/// Note: sentry-cli 3.2.0 fixed this upstream in getsentry/sentry-cli#3108.
+/// Once this plugin no longer needs to support older bundled CLI versions,
+/// this workaround can be replaced with the normal `--url` argument again.
 ///
 class DartSymbolMapUploader {
   /// Uploads [symbolMapPath] for each entry in [debugFilePaths].
@@ -64,7 +72,7 @@ class DartSymbolMapUploader {
             "Uploading Dart symbol map '$symbolMapPath' paired with '$debugFilePath'");
 
         final args = [
-          ...config.baseArgs(),
+          ...config.baseArgs(includeUrl: false),
           'dart-symbol-map',
           'upload',
           ...config.orgProjectArgs(),
@@ -76,6 +84,7 @@ class DartSymbolMapUploader {
           processManager: processManager,
           cliPath: cliPath,
           args: args,
+          environment: _environmentForDartSymbolMapUpload(config),
           errorContext: 'Failed to upload Dart symbol map for $debugFilePath',
         );
 
@@ -99,11 +108,15 @@ class DartSymbolMapUploader {
     required ProcessManager processManager,
     required String cliPath,
     required List<String> args,
+    Map<String, String>? environment,
     required String errorContext,
   }) async {
     int exitCode;
     try {
-      final Process process = await processManager.start([cliPath, ...args]);
+      final Process process = await processManager.start(
+        [cliPath, ...args],
+        environment: environment,
+      );
 
       process.stdout.transform(utf8.decoder).listen((String data) {
         final String trimmed = data.trim();
@@ -124,6 +137,16 @@ class DartSymbolMapUploader {
       return 1;
     }
     return exitCode;
+  }
+
+  static Map<String, String>? _environmentForDartSymbolMapUpload(
+    Configuration config,
+  ) {
+    final url = config.url;
+    if (url == null || url.isEmpty) {
+      return null;
+    }
+    return <String, String>{'SENTRY_URL': url};
   }
 
   /// Returns the debug id for the given [debugFilePath] by invoking:

--- a/lib/src/utils/sentry_cli_args.dart
+++ b/lib/src/utils/sentry_cli_args.dart
@@ -1,8 +1,8 @@
 import '../configuration.dart';
 
 extension SentryCliArgs on Configuration {
-  List<String> baseArgs() => [
-        if (url != null) ...['--url', url!],
+  List<String> baseArgs({bool includeUrl = true}) => [
+        if (includeUrl && url != null) ...['--url', url!],
         if (authToken != null) ...['--auth-token', authToken!],
         if (logLevel != null) ...['--log-level', logLevel!],
       ];

--- a/test/dart_symbol_map_uploader_test.dart
+++ b/test/dart_symbol_map_uploader_test.dart
@@ -18,7 +18,7 @@ void main() {
       injector.registerSingleton<ProcessManager>(() => pm, override: true);
     });
 
-    test('emits one command per debug file with all flags', () async {
+    test('emits one upload command per debug file with configured options', () async {
       final config = Configuration()
         ..cliPath = 'mock-cli'
         ..url = 'https://example.invalid'
@@ -49,11 +49,12 @@ void main() {
       expect(
         pm.commandLog[1],
         equals(
-          'mock-cli --url https://example.invalid --auth-token token --log-level debug '
+          'mock-cli --auth-token token --log-level debug '
           'dart-symbol-map upload --org my-org --project my-proj '
           '$map ${debugFiles[0]}',
         ),
       );
+      expect(pm.environmentLog[1], {'SENTRY_URL': 'https://example.invalid'});
       expect(
         pm.commandLog[2],
         equals(
@@ -63,11 +64,12 @@ void main() {
       expect(
         pm.commandLog[3],
         equals(
-          'mock-cli --url https://example.invalid --auth-token token --log-level debug '
+          'mock-cli --auth-token token --log-level debug '
           'dart-symbol-map upload --org my-org --project my-proj '
           '$map ${debugFiles[1]}',
         ),
       );
+      expect(pm.environmentLog[3], {'SENTRY_URL': 'https://example.invalid'});
     });
 
     test('omits optional flags when not configured', () async {
@@ -97,6 +99,7 @@ void main() {
         pm.commandLog[1],
         equals('mock-cli dart-symbol-map upload $map ${debugFiles.single}'),
       );
+      expect(pm.environmentLog[1], isNull);
     });
 
     test('propagates non-zero exit codes via ExitError', () async {
@@ -127,6 +130,7 @@ void main() {
 
 class MockProcessManager implements ProcessManager {
   final List<String> commandLog = <String>[];
+  final List<Map<String, String>?> environmentLog = <Map<String, String>?>[];
   List<int> exitCodes = <int>[]; // optional per-start exit codes
 
   @override
@@ -155,6 +159,8 @@ class MockProcessManager implements ProcessManager {
       covariant Encoding? stdoutEncoding = systemEncoding,
       covariant Encoding? stderrEncoding = systemEncoding}) {
     commandLog.add(command.join(' '));
+    environmentLog.add(
+        environment == null ? null : Map<String, String>.from(environment));
     final int code = exitCodes.isNotEmpty ? exitCodes.removeAt(0) : 0;
     return ProcessResult(-1, code, null, null);
   }
@@ -167,6 +173,8 @@ class MockProcessManager implements ProcessManager {
       bool runInShell = false,
       ProcessStartMode mode = ProcessStartMode.normal}) async {
     commandLog.add(command.join(' '));
+    environmentLog.add(
+        environment == null ? null : Map<String, String>.from(environment));
     final int code = exitCodes.isNotEmpty ? exitCodes.removeAt(0) : 0;
     return MockProcess(code);
   }

--- a/test/plugin_test.dart
+++ b/test/plugin_test.dart
@@ -237,32 +237,46 @@ void main() {
           final commandLog = await runWith(version, config);
           const release = '$name@$version';
 
-          final args = '$commonArgs --log-level debug';
+          final uploadIndex = pm.commandLog.indexWhere(
+            (e) => e.contains('dart-symbol-map upload '),
+          );
+          expect(uploadIndex, isNonNegative);
+          final uploadCommand = pm.commandLog[uploadIndex];
+          const dartSymbolMapArgs = '--auth-token t --log-level debug ';
+          final relStart =
+              '$cli ${dartSymbolMapArgs}dart-symbol-map upload $orgAndProject ${mapFile.path} ';
+          final absStart =
+              '$cli ${dartSymbolMapArgs}dart-symbol-map upload $orgAndProject ${fs.file(mapFile.path).absolute.path} ';
           expect(
-            commandLog,
-            anyElement((e) {
-              final relStart =
-                  '$cli $args dart-symbol-map upload $orgAndProject ${mapFile.path} ';
-              final absStart =
-                  '$cli $args dart-symbol-map upload $orgAndProject ${fs.file(mapFile.path).absolute.path} ';
-              return (e.startsWith(relStart) || e.startsWith(absStart)) &&
-                  e.endsWith('$buildDir/app/outputs/app-release.symbols');
-            }),
+            (uploadCommand.startsWith(relStart) ||
+                    uploadCommand.startsWith(absStart)) &&
+                uploadCommand
+                    .endsWith('$buildDir/app/outputs/app-release.symbols'),
+            isTrue,
+          );
+          expect(uploadCommand.contains('--url'), isFalse);
+          expect(
+            pm.commandEnvironmentLog[uploadIndex],
+            url == null ? isNull : {'SENTRY_URL': url},
           );
 
           // Ensure other expected commands still present
           expect(
               commandLog,
               contains(
-                  '$cli $args debug-files upload $orgAndProject $buildDir/app/outputs'));
-          expect(commandLog,
-              contains('$cli $args releases $orgAndProject new $release'));
+                  '$cli $commonArgs --log-level debug debug-files upload $orgAndProject $buildDir/app/outputs'));
           expect(
               commandLog,
               contains(
-                  '$cli $args releases $orgAndProject set-commits $release --auto'));
-          expect(commandLog,
-              contains('$cli $args releases $orgAndProject finalize $release'));
+                  '$cli $commonArgs --log-level debug releases $orgAndProject new $release'));
+          expect(
+              commandLog,
+              contains(
+                  '$cli $commonArgs --log-level debug releases $orgAndProject set-commits $release --auto'));
+          expect(
+              commandLog,
+              contains(
+                  '$cli $commonArgs --log-level debug releases $orgAndProject finalize $release'));
         });
 
         group('release', () {
@@ -507,6 +521,7 @@ void main() {
 
 class MockProcessManager implements ProcessManager {
   final commandLog = <String>[];
+  final commandEnvironmentLog = <Map<String, String>?>[];
 
   @override
   bool canRun(executable, {String? workingDirectory}) => true;
@@ -534,6 +549,8 @@ class MockProcessManager implements ProcessManager {
       covariant Encoding? stdoutEncoding = systemEncoding,
       covariant Encoding? stderrEncoding = systemEncoding}) {
     commandLog.add(command.join(' '));
+    commandEnvironmentLog.add(
+        environment == null ? null : Map<String, String>.from(environment));
     return ProcessResult(-1, 0, null, null);
   }
 
@@ -545,6 +562,8 @@ class MockProcessManager implements ProcessManager {
       bool runInShell = false,
       ProcessStartMode mode = ProcessStartMode.normal}) {
     commandLog.add(command.join(' '));
+    commandEnvironmentLog.add(
+        environment == null ? null : Map<String, String>.from(environment));
     return Future.value(MockProcess());
   }
 }


### PR DESCRIPTION


## :scroll: Description
<!--- Describe your changes in detail -->

Older sentry-cli versions reject --url for dart-symbol-map upload, which breaks uploads against custom Sentry URLs.

This switches Dart symbol map uploads to use SENTRY_URL instead of --url, keeping compatibility with older CLI versions while continuing to work with newer ones.

Includes test coverage for the new invocation behavior.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Upstream fix landed in sentry-cli 3.2.0 via getsentry/sentry-cli#3108

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
