### PR TITLE
feat(sentry-cli): Add `SENTRY_CLI_BIN_PATH` env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `SENTRY_CLI_BIN_PATH` env variable ([#398](https://github.com/getsentry/sentry-dart-plugin/pull/398))
+
 ## 3.3.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ A Dart Build Plugin that uploads debug symbols for Android, iOS/macOS and source
 ## Installation and Usage
 
 Please refer to [Sentry Dart Plugin's documentation page](https://docs.sentry.io/platforms/dart/guides/flutter/debug-symbols/).
+
+## Custom sentry-cli binary
+
+Set `SENTRY_CLI_BIN_PATH=/path/to/sentry-cli` to use a pre-installed
+`sentry-cli` binary instead of downloading one.
+
+The `bin_path` setting in `pubspec.yaml` remains supported for backwards
+compatibility, but it is an arbitrary executable override. Only use it with
+trusted project configuration.

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -99,6 +99,7 @@ class Configuration {
 
   /// An alternative path to sentry-cli. If provided, the SDK will not be
   /// downloaded. Please make sure to use the matching version.
+  /// Prefer setting this locally with SENTRY_CLI_BIN_PATH.
   late String? binPath;
 
   /// Place to download sentry-cli. Defaults to
@@ -145,6 +146,12 @@ class Configuration {
       file: fileConfig,
       platformEnv: platformEnvConfig,
     );
+    _warnIfUsingPubspecBinPath(
+      argsConfig: argsConfig,
+      fileConfig: fileConfig,
+      platformEnvConfig: platformEnvConfig,
+      pubspecBinPath: _readPubspecBinPath(pubspec),
+    );
 
     release = configValues.release;
     dist = configValues.dist;
@@ -182,6 +189,39 @@ class Configuration {
     sentryCliVersion = configValues.sentryCliVersion;
     legacyWebSymbolication = configValues.legacyWebSymbolication ?? false;
     ignoreWebSourcePaths = configValues.ignoreWebSourcePaths ?? [];
+  }
+
+  void _warnIfUsingPubspecBinPath({
+    required ConfigurationValues argsConfig,
+    required ConfigurationValues fileConfig,
+    required ConfigurationValues platformEnvConfig,
+    required String? pubspecBinPath,
+  }) {
+    if (_hasValue(pubspecBinPath) &&
+        fileConfig.binPath == pubspecBinPath &&
+        !_hasValue(argsConfig.binPath) &&
+        !_hasValue(platformEnvConfig.binPath)) {
+      Log.warn('bin_path is configured in pubspec.yaml. This is an intentional '
+          'arbitrary executable override and will be executed directly as '
+          'sentry-cli. Only use this with trusted project configuration. '
+          'Prefer SENTRY_CLI_BIN_PATH for user-local configuration.');
+    }
+  }
+
+  bool _hasValue(String? value) {
+    return value != null && value.isNotEmpty;
+  }
+
+  String? _readPubspecBinPath(dynamic pubspec) {
+    if (pubspec is! Map) {
+      return null;
+    }
+    final sentryConfig = pubspec['sentry'];
+    if (sentryConfig is! Map || !sentryConfig.containsKey('bin_path')) {
+      return null;
+    }
+    final binPath = sentryConfig['bin_path']?.toString();
+    return _hasValue(binPath) ? binPath : null;
   }
 
   /// Validates the configuration values and log an error if required fields

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -199,8 +199,8 @@ class Configuration {
   }) {
     if (_hasValue(pubspecBinPath) &&
         fileConfig.binPath == pubspecBinPath &&
-        !_hasValue(argsConfig.binPath) &&
-        !_hasValue(platformEnvConfig.binPath)) {
+        argsConfig.binPath == null &&
+        platformEnvConfig.binPath == null) {
       Log.warn('bin_path is configured in pubspec.yaml. This is an intentional '
           'arbitrary executable override and will be executed directly as '
           'sentry-cli. Only use this with trusted project configuration. '

--- a/lib/src/configuration_values.dart
+++ b/lib/src/configuration_values.dart
@@ -161,27 +161,23 @@ class ConfigurationValues {
   factory ConfigurationValues.fromPlatformEnvironment(
     Map<String, String> environment,
   ) {
-    String? envRelease = environment['SENTRY_RELEASE'];
-    if (envRelease?.isEmpty ?? false) {
-      envRelease = null;
+    String? envValue(String key) {
+      final value = environment[key];
+      return value == null || value.isEmpty ? null : value;
     }
-    String? envDist = environment['SENTRY_DIST'];
-    if (envDist?.isEmpty ?? false) {
-      envDist = null;
-    }
-    String? envSentryCliCdnUrl = environment['SENTRYCLI_CDNURL'];
-    if (envSentryCliCdnUrl?.isEmpty ?? false) {
-      envSentryCliCdnUrl = null;
-    }
-    String? envLogLevel = environment['SENTRY_LOG_LEVEL'];
-    if (envLogLevel?.isEmpty ?? false) {
-      envLogLevel = null;
-    }
+
+    final envRelease = envValue('SENTRY_RELEASE');
+    final envDist = envValue('SENTRY_DIST');
+    final envSentryCliCdnUrl = envValue('SENTRYCLI_CDNURL');
+    final envLogLevel = envValue('SENTRY_LOG_LEVEL');
+    final envBinPath = envValue('SENTRY_CLI_BIN_PATH');
+
     return ConfigurationValues(
       release: envRelease,
       dist: envDist,
       sentryCliCdnUrl: envSentryCliCdnUrl,
       logLevel: envLogLevel,
+      binPath: envBinPath,
     );
   }
 
@@ -214,7 +210,7 @@ class ConfigurationValues {
       commits: args.commits ?? file.commits,
       ignoreMissing: args.ignoreMissing ?? file.ignoreMissing,
       binDir: args.binDir ?? file.binDir,
-      binPath: args.binPath ?? file.binPath,
+      binPath: platformEnv.binPath ?? args.binPath ?? file.binPath,
       sentryCliCdnUrl: platformEnv.sentryCliCdnUrl ??
           args.sentryCliCdnUrl ??
           file.sentryCliCdnUrl,

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -25,16 +25,19 @@ void main() {
         release: 'release-platformEnv-config',
         dist: 'dist-platformEnv-config',
         sentryCliCdnUrl: 'sentryCliCdnUrl-platformEnv-config',
+        binPath: 'binPath-platformEnv-config',
       );
       final argsConfig = ConfigurationValues(
         release: 'release-args-config',
         dist: 'dist-args-config',
         sentryCliCdnUrl: 'sentryCliCdnUrl-args-config',
+        binPath: 'binPath-args-config',
       );
       final fileConfig = ConfigurationValues(
         release: 'release-file-config',
         dist: 'dist-file-config',
         sentryCliCdnUrl: 'sentryCliCdnUrl-file-config',
+        binPath: 'binPath-file-config',
       );
 
       final sut = fixture.getSut(
@@ -46,6 +49,7 @@ void main() {
       expect(sut.release, 'release-platformEnv-config');
       expect(sut.dist, 'dist-platformEnv-config');
       expect(sut.sentryCliCdnUrl, 'sentryCliCdnUrl-platformEnv-config');
+      expect(sut.binPath, 'binPath-platformEnv-config');
     });
 
     // env config

--- a/test/configuration_values_test.dart
+++ b/test/configuration_values_test.dart
@@ -290,6 +290,7 @@ void main() {
         'SENTRY_DIST': 'fixture-dist',
         'SENTRYCLI_CDNURL': 'fixture-sentry_cli_cdn_url',
         'SENTRY_LOG_LEVEL': 'debug',
+        'SENTRY_CLI_BIN_PATH': 'fixture-bin-path',
       };
 
       final sut = ConfigurationValues.fromPlatformEnvironment(arguments);
@@ -297,15 +298,18 @@ void main() {
       expect(sut.dist, 'fixture-dist');
       expect(sut.sentryCliCdnUrl, 'fixture-sentry_cli_cdn_url');
       expect(sut.logLevel, 'debug');
+      expect(sut.binPath, 'fixture-bin-path');
     });
 
-    test("fromPlatformEnvironment handles empty SENTRY_LOG_LEVEL", () {
+    test("fromPlatformEnvironment handles empty environment values", () {
       final arguments = {
         'SENTRY_LOG_LEVEL': '',
+        'SENTRY_CLI_BIN_PATH': '',
       };
 
       final sut = ConfigurationValues.fromPlatformEnvironment(arguments);
       expect(sut.logLevel, isNull);
+      expect(sut.binPath, isNull);
     });
 
     test("merged gives priority to platformEnv.logLevel over args and file",
@@ -321,6 +325,35 @@ void main() {
       );
 
       expect(sut.logLevel, 'env-log-level');
+    });
+
+    test("merged gives priority to platformEnv.binPath over args and file", () {
+      final platformEnv = ConfigurationValues(binPath: 'env-bin-path');
+      final args = ConfigurationValues(binPath: 'args-bin-path');
+      final file = ConfigurationValues(binPath: 'file-bin-path');
+
+      final sut = ConfigurationValues.merged(
+        platformEnv: platformEnv,
+        args: args,
+        file: file,
+      );
+
+      expect(sut.binPath, 'env-bin-path');
+    });
+
+    test("merged falls back to args.binPath when platformEnv.binPath is null",
+        () {
+      final platformEnv = ConfigurationValues();
+      final args = ConfigurationValues(binPath: 'args-bin-path');
+      final file = ConfigurationValues(binPath: 'file-bin-path');
+
+      final sut = ConfigurationValues.merged(
+        platformEnv: platformEnv,
+        args: args,
+        file: file,
+      );
+
+      expect(sut.binPath, 'args-bin-path');
     });
 
     test("merged falls back to args.logLevel when platformEnv.logLevel is null",

--- a/test/configuration_values_test.dart
+++ b/test/configuration_values_test.dart
@@ -356,6 +356,20 @@ void main() {
       expect(sut.binPath, 'args-bin-path');
     });
 
+    test("merged treats empty args.binPath as an explicit value", () {
+      final platformEnv = ConfigurationValues();
+      final args = ConfigurationValues(binPath: '');
+      final file = ConfigurationValues(binPath: 'file-bin-path');
+
+      final sut = ConfigurationValues.merged(
+        platformEnv: platformEnv,
+        args: args,
+        file: file,
+      );
+
+      expect(sut.binPath, '');
+    });
+
     test("merged falls back to args.logLevel when platformEnv.logLevel is null",
         () {
       final platformEnv = ConfigurationValues();


### PR DESCRIPTION
## Summary
- add SENTRY_CLI_BIN_PATH as the preferred local override for a pre-installed sentry-cli
- warn when pubspec.yaml bin_path is used because it executes an arbitrary configured binary
- document the trust boundary and add config precedence coverage

## Tests
- dart analyze
- dart test test/configuration_values_test.dart test/configuration_test.dart
- dart test test/plugin_test.dart