### PR TITLE
fix: Prevent stale dart symbol map debug ID markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleases
+
+### Fixes
+
+- Prevent stale dart symbol map debug ID markers ([#403](https://github.com/getsentry/sentry-dart-plugin/pull/403))
+
 ## 3.3.0
 
 ### Features

--- a/lib/src/symbol_maps/dart_symbol_map_uploader.dart
+++ b/lib/src/symbol_maps/dart_symbol_map_uploader.dart
@@ -62,8 +62,12 @@ class DartSymbolMapUploader {
           debugFilePath: debugFilePath,
         );
         if (debugId != null && debugId.isNotEmpty) {
-          await _prependDebugIdMarkerToMapFile(symbolMapPath, debugId);
+          await _updateDebugIdMarkerInMapFile(symbolMapPath, debugId);
+          Log.info('Resolved debug id "$debugId" for "$debugFilePath".');
         } else {
+          // Clear any marker left by a previous iteration so this upload cannot
+          // be associated with the wrong debug file if debug-id lookup fails.
+          await _updateDebugIdMarkerInMapFile(symbolMapPath, null);
           Log.warn(
               'Could not resolve debug id for "$debugFilePath". Proceeding without map modification.');
         }
@@ -88,16 +92,26 @@ class DartSymbolMapUploader {
           errorContext: 'Failed to upload Dart symbol map for $debugFilePath',
         );
 
+        final String debugIdSuffix = debugId != null && debugId.isNotEmpty
+            ? ' with debug id "$debugId"'
+            : '';
         if (exitCode == 0) {
           succeeded++;
+          Log.info(
+              'Dart symbol map upload succeeded for "$debugFilePath"$debugIdSuffix.');
         } else {
           failed++;
+          Log.warn(
+              'Dart symbol map upload failed for "$debugFilePath"$debugIdSuffix.');
         }
 
         // Propagate non-zero exit code consistently with the plugin behavior.
         Log.processExitCode(exitCode);
       }
     } finally {
+      // The marker is only an upload-time checksum discriminator. Remove it so
+      // the user-provided obfuscation map is not left modified after the run.
+      await _updateDebugIdMarkerInMapFile(symbolMapPath, null);
       Log.info(
           'Dart symbol map upload summary: attempted=$attempted, succeeded=$succeeded, failed=$failed');
     }
@@ -118,13 +132,15 @@ class DartSymbolMapUploader {
         environment: environment,
       );
 
-      process.stdout.transform(utf8.decoder).listen((String data) {
+      final Future<void> stdoutDone =
+          process.stdout.transform(utf8.decoder).forEach((String data) {
         final String trimmed = data.trim();
         if (trimmed.isNotEmpty) {
           Log.info(trimmed);
         }
       });
-      process.stderr.transform(utf8.decoder).listen((String data) {
+      final Future<void> stderrDone =
+          process.stderr.transform(utf8.decoder).forEach((String data) {
         final String trimmed = data.trim();
         if (trimmed.isNotEmpty) {
           Log.error(trimmed);
@@ -132,6 +148,7 @@ class DartSymbolMapUploader {
       });
 
       exitCode = await process.exitCode;
+      await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
     } on Exception catch (exception) {
       Log.error('$errorContext: \n$exception');
       return 1;
@@ -169,10 +186,13 @@ class DartSymbolMapUploader {
       final StringBuffer stdoutBuffer = StringBuffer();
       final StringBuffer stderrBuffer = StringBuffer();
 
-      process.stdout.transform(utf8.decoder).listen(stdoutBuffer.write);
-      process.stderr.transform(utf8.decoder).listen(stderrBuffer.write);
+      final Future<void> stdoutDone =
+          process.stdout.transform(utf8.decoder).forEach(stdoutBuffer.write);
+      final Future<void> stderrDone =
+          process.stderr.transform(utf8.decoder).forEach(stderrBuffer.write);
 
       final int code = await process.exitCode;
+      await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
       if (code != 0) {
         Log.warn(
             'Failed to fetch debug id for "$debugFilePath" (exit=$code): ${stderrBuffer.toString().trim()}');
@@ -209,16 +229,21 @@ class DartSymbolMapUploader {
 
   static const _debugIdMarker = 'SENTRY_DEBUG_ID_MARKER';
 
-  /// Reads the Dart symbol map at [mapPath] and ensures the array starts with
-  /// ["SENTRY_DEBUG_ID_MARKER", debugId]. If a previous marker is present, it
-  /// will be replaced.
-  static Future<void> _prependDebugIdMarkerToMapFile(
-      String mapPath, String debugId) async {
+  /// Reads the Dart symbol map at [mapPath] and updates the leading debug id
+  /// marker. If [debugId] is non-null, the array starts with
+  /// ["SENTRY_DEBUG_ID_MARKER", debugId]. If [debugId] is null, any previous
+  /// marker is removed.
+  static Future<void> _updateDebugIdMarkerInMapFile(
+    String mapPath,
+    String? debugId,
+  ) async {
     try {
       final File file = File(mapPath);
       if (!await file.exists()) {
-        Log.warn(
-            "Cannot modify Dart symbol map: file does not exist at '$mapPath'.");
+        if (debugId != null) {
+          Log.warn(
+              "Cannot modify Dart symbol map: file does not exist at '$mapPath'.");
+        }
         return;
       }
 
@@ -233,24 +258,27 @@ class DartSymbolMapUploader {
       final List<dynamic> original = List<dynamic>.from(decoded);
 
       // If the file already has the same marker, do nothing to keep it untouched.
-      if (original.length >= 2 &&
+      if (debugId != null &&
+          original.length >= 2 &&
           original[0] == _debugIdMarker &&
           original[1] == debugId) {
         return;
       }
 
-      List<dynamic> tail;
-      if (original.isNotEmpty && original.first == _debugIdMarker) {
-        tail = original.length > 2 ? original.sublist(2) : <dynamic>[];
-      } else {
-        tail = original;
-      }
+      final List<dynamic> tail =
+          original.isNotEmpty && original.first == _debugIdMarker
+              ? original.length > 2
+                  ? original.sublist(2)
+                  : <dynamic>[]
+              : original;
 
-      final List<dynamic> updated = <dynamic>[
-        _debugIdMarker,
-        debugId,
-        ...tail,
-      ];
+      final List<dynamic> updated = debugId == null
+          ? tail
+          : <dynamic>[
+              _debugIdMarker,
+              debugId,
+              ...tail,
+            ];
 
       await file.writeAsString(jsonEncode(updated));
     } catch (e) {

--- a/test/dart_symbol_map_uploader_test.dart
+++ b/test/dart_symbol_map_uploader_test.dart
@@ -18,7 +18,8 @@ void main() {
       injector.registerSingleton<ProcessManager>(() => pm, override: true);
     });
 
-    test('emits one upload command per debug file with configured options', () async {
+    test('emits one upload command per debug file with configured options',
+        () async {
       final config = Configuration()
         ..cliPath = 'mock-cli'
         ..url = 'https://example.invalid'
@@ -102,6 +103,48 @@ void main() {
       expect(pm.environmentLog[1], isNull);
     });
 
+    test('waits for debug-id stdout before uploading each map', () async {
+      final mapFile = await _createTempMapFile();
+      final uploadedMapContents = <String>[];
+      pm.handleStart = (List<Object> command) async {
+        if (command.contains('dart-symbol-map')) {
+          uploadedMapContents.add(
+            await File(command[command.length - 2].toString()).readAsString(),
+          );
+          return MockProcess(0);
+        }
+
+        final bool isArm64 = command.last.toString().contains('arm64');
+        return MockProcess(
+          0,
+          stdoutText:
+              _debugCheckJson(isArm64 ? 'debug-id-arm64' : 'debug-id-arm'),
+          stdoutDelay:
+              isArm64 ? const Duration(milliseconds: 20) : Duration.zero,
+          exitCodeDelay:
+              isArm64 ? Duration.zero : const Duration(milliseconds: 20),
+        );
+      };
+
+      await DartSymbolMapUploader.addDebugIdMarkerAndUpload(
+        config: _minimalConfig(),
+        symbolMapPath: mapFile.path,
+        debugFilePaths: <String>[
+          '/debug/app.android-arm.symbols',
+          '/debug/app.android-arm64.symbols',
+        ],
+      );
+
+      expect(uploadedMapContents, <String>[
+        _mapWithDebugId('debug-id-arm'),
+        _mapWithDebugId('debug-id-arm64'),
+      ]);
+      // The marker is only needed for upload and must not remain on the
+      // user-provided obfuscation map after all uploads finish.
+      expect(
+          await mapFile.readAsString(), jsonEncode(<String>['symbol', 'name']));
+    });
+
     test('propagates non-zero exit codes via ExitError', () async {
       // First debug-id check succeeds, then the first upload fails.
       pm.exitCodes = <int>[0, 1];
@@ -128,10 +171,49 @@ void main() {
   });
 }
 
+Configuration _minimalConfig() => Configuration()
+  ..cliPath = 'mock-cli'
+  ..org = 'o'
+  ..project = 'p'
+  ..url = null
+  ..authToken = null
+  ..logLevel = null;
+
+Future<File> _createTempMapFile() async {
+  final tempDir = await Directory.systemTemp.createTemp(
+    'sentry-dart-symbol-map-test-',
+  );
+  addTearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  final mapFile = File(
+    '${tempDir.path}${Platform.pathSeparator}obfuscation_map.json',
+  );
+  await mapFile.writeAsString(jsonEncode(<String>['symbol', 'name']));
+  return mapFile;
+}
+
+String _debugCheckJson(String debugId) => jsonEncode(<String, Object>{
+      'variants': <Map<String, String>>[
+        <String, String>{'debug_id': debugId},
+      ],
+    });
+
+String _mapWithDebugId(String debugId) => jsonEncode(<String>[
+      'SENTRY_DEBUG_ID_MARKER',
+      debugId,
+      'symbol',
+      'name',
+    ]);
+
 class MockProcessManager implements ProcessManager {
   final List<String> commandLog = <String>[];
   final List<Map<String, String>?> environmentLog = <Map<String, String>?>[];
   List<int> exitCodes = <int>[]; // optional per-start exit codes
+  Future<Process> Function(List<Object> command)? handleStart;
 
   @override
   bool canRun(executable, {String? workingDirectory}) => true;
@@ -175,6 +257,10 @@ class MockProcessManager implements ProcessManager {
     commandLog.add(command.join(' '));
     environmentLog.add(
         environment == null ? null : Map<String, String>.from(environment));
+    if (handleStart != null) {
+      return handleStart!(command);
+    }
+
     final int code = exitCodes.isNotEmpty ? exitCodes.removeAt(0) : 0;
     return MockProcess(code);
   }
@@ -182,10 +268,28 @@ class MockProcessManager implements ProcessManager {
 
 class MockProcess implements Process {
   final int _exitCode;
-  MockProcess(this._exitCode);
+  final String stdoutText;
+  final String stderrText;
+  final Duration stdoutDelay;
+  final Duration stderrDelay;
+  final Duration exitCodeDelay;
+
+  MockProcess(
+    this._exitCode, {
+    this.stdoutText = '',
+    this.stderrText = '',
+    this.stdoutDelay = Duration.zero,
+    this.stderrDelay = Duration.zero,
+    this.exitCodeDelay = Duration.zero,
+  });
 
   @override
-  Future<int> get exitCode => Future<int>.value(_exitCode);
+  Future<int> get exitCode async {
+    if (exitCodeDelay != Duration.zero) {
+      await Future<void>.delayed(exitCodeDelay);
+    }
+    return _exitCode;
+  }
 
   @override
   bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => false;
@@ -194,11 +298,20 @@ class MockProcess implements Process {
   int get pid => -1;
 
   @override
-  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+  Stream<List<int>> get stderr => _delayedTextStream(stderrText, stderrDelay);
 
   @override
   IOSink get stdin => throw UnimplementedError();
 
   @override
-  Stream<List<int>> get stdout => const Stream<List<int>>.empty();
+  Stream<List<int>> get stdout => _delayedTextStream(stdoutText, stdoutDelay);
+
+  Stream<List<int>> _delayedTextStream(String text, Duration delay) async* {
+    if (delay != Duration.zero) {
+      await Future<void>.delayed(delay);
+    }
+    if (text.isNotEmpty) {
+      yield utf8.encode(text);
+    }
+  }
 }

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -250,6 +250,11 @@ Future<Directory> _prepareTestApp(Directory tempDir, String platform) async {
   final buildArgs = [
     platform,
     if (['ipa', 'ios'].contains(platform)) '--no-codesign',
+    // Framework integration tests only inspect Release outputs. Avoid building
+    // Debug/Profile because newer Flutter versions require Apple development
+    // signing for those configurations on hosted CI runners.
+    if (['ios-framework', 'macos-framework'].contains(platform)) '--no-debug',
+    if (['ios-framework', 'macos-framework'].contains(platform)) '--no-profile',
     if (platform == 'web') '--source-maps',
     if (platform != 'web') '--split-debug-info=symbols',
     if (platform != 'web') '--obfuscate',

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -249,7 +249,8 @@ Future<Directory> _prepareTestApp(Directory tempDir, String platform) async {
   }
   final buildArgs = [
     platform,
-    if (['ipa', 'ios'].contains(platform)) '--no-codesign',
+    if (['ipa', 'ios', 'ios-framework', 'macos-framework'].contains(platform))
+      '--no-codesign',
     // Framework integration tests only inspect Release outputs. Avoid building
     // Debug/Profile because newer Flutter versions require Apple development
     // signing for those configurations on hosted CI runners.


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fixes Dart symbol map uploads so each ABI uses the correct debug ID.

The uploader now waits for `debug-files check --json` stdout/stderr to finish, clears stale markers when debug ID lookup fails, and removes the marker after uploads.

Added regression coverage for delayed stdout and marker cleanup.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #401

## :green_heart: How did you test it?

Unit tests. Sample app that created 3 symbols with each uploading the same symbol map with id injected.

<img width="2200" height="1061" alt="Bildschirmfoto 2026-05-28 um 10 53 02" src="https://github.com/user-attachments/assets/24e6e854-492c-4b16-98d4-f67433182f19" />

[issue_401_fixed_repro.txt](https://github.com/user-attachments/files/28341736/issue_401_fixed_repro.txt)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes