### PR TITLE
ci: Notify linked issues on release

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,0 +1,39 @@
+name: 'Automation: Notify issues for release'
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-24.04
+    name: 'Notify issues'
+    steps:
+      - name: Get version
+        id: get_version
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on linked issues that are mentioned in release
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
+
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,13 @@
 We love pull requests from everyone. 
 We suggest opening an issue to discuss bigger changes before investing on a big PR.
 
+# Pull Requests
+
+If a PR should notify a linked issue after release, use a GitHub closing keyword in the PR
+description, such as `Fixes #123`, `Closes #123`, or `Resolves #123`. Release notification
+automation only comments on issues GitHub recognizes as closed by the released PR; mentioning an
+issue without a closing keyword is not enough.
+
 # Requirements
 
 The project currently requires you run Dart version >= `2.12.0`.


### PR DESCRIPTION
Add release automation that comments on GitHub issues closed by PRs included in a published stable release.

This mirrors the release issue notification automation used by other Sentry SDK repositories and makes the required PR issue-linking behavior explicit for contributors.

PR authors need to use GitHub closing keywords, such as `Fixes #123`, for linked issues to receive the release notification.