### PR TITLE
docs: Update 3.4.0 changelog categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.4.0
 
+### Dependencies
+
+- (sentry-cli) Upgrade to 2.58.6 by @szokeasaurusrex in [#402](https://github.com/getsentry/sentry-dart-plugin/pull/402)
+
 ### Bug Fixes 🐛
 
 - Prevent stale dart symbol map debug ID markers by @denrase in [#403](https://github.com/getsentry/sentry-dart-plugin/pull/403)
@@ -9,7 +13,6 @@
 ### Internal Changes 🔧
 
 - (deps) Bump getsentry/craft from 2.19.0 to 2.25.2 by @dependabot in [#390](https://github.com/getsentry/sentry-dart-plugin/pull/390)
-- (sentry-cli) Upgrade to 2.58.6 by @szokeasaurusrex in [#402](https://github.com/getsentry/sentry-dart-plugin/pull/402)
 - Notify linked issues on release by @buenaflor in [#404](https://github.com/getsentry/sentry-dart-plugin/pull/404)
 
 ## Unreleases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- (sentry-cli) Upgrade to 2.58.6 by @szokeasaurusrex in [#402](https://github.com/getsentry/sentry-dart-plugin/pull/402)
+- Bump sentry-cli to v2.58.6 by @szokeasaurusrex in [#402](https://github.com/getsentry/sentry-dart-plugin/pull/402)
 
 ### Bug Fixes 🐛
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,14 @@
 
 - Bump sentry-cli to v2.58.6 by @szokeasaurusrex in [#402](https://github.com/getsentry/sentry-dart-plugin/pull/402)
 
-### Bug Fixes 🐛
+### Fixes
 
 - Prevent stale dart symbol map debug ID markers by @denrase in [#403](https://github.com/getsentry/sentry-dart-plugin/pull/403)
 
-### Internal Changes 🔧
+### Internal Changes
 
 - (deps) Bump getsentry/craft from 2.19.0 to 2.25.2 by @dependabot in [#390](https://github.com/getsentry/sentry-dart-plugin/pull/390)
 - Notify linked issues on release by @buenaflor in [#404](https://github.com/getsentry/sentry-dart-plugin/pull/404)
-
-## Unreleases
-
-### Fixes
-
-- Prevent stale dart symbol map debug ID markers ([#403](https://github.com/getsentry/sentry-dart-plugin/pull/403))
 
 ## 3.3.0
 


### PR DESCRIPTION
Move the sentry-cli upgrade entry into the Dependencies section of the 3.4.0 changelog.

The entry was generated under Internal Changes, but it is a dependency update and should be grouped with the other dependency-related release notes.

Made with [Cursor](https://cursor.com)